### PR TITLE
Initial version of Diameter Accountung RFC 7155

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
 *~
 *.beam
 /ebin/*.app
+/_build
+/log*
 
 /tetrapak/.local.cache
+
+# diameter compiler atrifacts
+/src/diameter_*
+/include/diameter_*

--- a/dia/diameter_nasreq_rfc7155.dia
+++ b/dia/diameter_nasreq_rfc7155.dia
@@ -1,0 +1,366 @@
+;; Copyright 2017, Travelping GmbH <info@travelping.com>
+
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License
+;; as published by the Free Software Foundation; either version
+;; 2 of the License, or (at your option) any later version.
+
+@id 1
+@name   diameter_nasreq_rfc7155
+@prefix diameter_nasreq
+@vendor 0 IETF
+
+@inherits diameter_gen_base_rfc6733
+
+@avp_types
+
+   Accounting-Auth-Method       406    Enumerated       M
+   Accounting-Input-Octets      363    Unsigned64       M
+   Accounting-Input-Packets     365    Unsigned64       M
+   Accounting-Output-Octets     364    Unsigned64       M
+   Accounting-Output-Packets    366    Unsigned64       M
+   Acct-Authentic               45     Enumerated       M
+   Acct-Delay-Time              41     Unsigned32       M
+   Acct-Link-Count              51     Unsigned32       M
+   Acct-Session-Time            46     Unsigned32       M
+   Acct-Tunnel-Connection       68     OctetString      M
+   Acct-Tunnel-Packets-Lost     86     Unsigned32       M
+   Callback-Id                  20     UTF8String       M
+   Callback-Number              19     UTF8String       M
+   Called-Station-Id            30     UTF8String       M
+   Calling-Station-Id           31     UTF8String       M
+   Connect-Info                 77     UTF8String       M
+   Filter-Id                    11     UTF8String       M
+   Framed-Appletalk-Link        37     Unsigned32       M
+   Framed-Appletalk-Network     38     Unsigned32       M
+   Framed-Appletalk-Zone        39     OctetString      M
+   Framed-Compression           13     Enumerated       M
+   Framed-IP-Address            8      OctetString      M
+   Framed-IP-Netmask            9      OctetString      M
+   Framed-IPX-Network           23     Unsigned32       M
+   Framed-IPv6-Pool             100    OctetString      M
+   Framed-IPv6-Prefix           97     OctetString      M
+   Framed-IPv6-Route            99     UTF8String       M
+   Framed-Interface-Id          96     Unsigned64       M
+   Framed-MTU                   12     Unsigned32       M
+   Framed-Pool                  88     OctetString      M
+   Framed-Protocol              7      Enumerated       M
+   Framed-Route                 22     UTF8String       M
+   Framed-Routing               10     Enumerated       M
+   Idle-Timeout                 28     Unsigned32       M
+   Login-IP-Host                14     OctetString      M
+   Login-IPv6-Host              98     OctetString      M
+   Login-LAT-Group              36     OctetString      M
+   Login-LAT-Node               35     OctetString      M
+   Login-LAT-Port               63     OctetString      M
+   Login-LAT-Service            34     OctetString      M
+   Login-Service                15     Enumerated       M
+   Login-TCP-Port               16     Unsigned32       M
+   NAS-Filter-Rule              400    IPFilterRule     M
+   NAS-IP-Address               4      OctetString      M
+   NAS-IPv6-Address             95     OctetString      M
+   NAS-Identifier               32     UTF8String       M
+   NAS-Port                     5      Unsigned32       M
+   NAS-Port-Id                  87     UTF8String       M
+   NAS-Port-Type                61     Enumerated       M
+   Origin-AAA-Protocol          408    Enumerated       M
+   Originating-Line-Info        94     OctetString      M
+   Port-Limit                   62     Unsigned32       M
+   QoS-Filter-Rule              407    QoSFilterRule    M
+   Service-Type                 6      Enumerated       M
+   Tunnel-Assignment-Id         82     OctetString      M
+   Tunnel-Client-Auth-Id        90     UTF8String       M
+   Tunnel-Client-Endpoint       66     UTF8String       M
+   Tunnel-Medium-Type           65     Enumerated       M
+   Tunnel-Password              69     OctetString      M
+   Tunnel-Preference            83     Unsigned32       M
+   Tunnel-Private-Group-Id      81     OctetString      M
+   Tunnel-Server-Auth-Id        91     UTF8String       M
+   Tunnel-Server-Endpoint       67     UTF8String       M
+   Tunnel-Type                  64     Enumerated       M
+   Tunneling                    401    Grouped          M
+
+@messages
+
+      ACR ::= <Diameter Header: 271, REQ, PXY>
+              < Session-Id >
+              { Origin-Host }
+              { Origin-Realm }
+              { Destination-Realm }
+              { Accounting-Record-Type }
+              { Accounting-Record-Number }
+              { Acct-Application-Id }
+              [ User-Name ]
+              [ Accounting-Sub-Session-Id ]
+              [ Acct-Session-Id ]
+              [ Acct-Multi-Session-Id ]
+              [ Origin-AAA-Protocol ]
+              [ Origin-State-Id ]
+              [ Destination-Host ]
+              [ Event-Timestamp ]
+              [ Acct-Delay-Time ]
+              [ NAS-Identifier ]
+              [ NAS-IP-Address ]
+              [ NAS-IPv6-Address ]
+              [ NAS-Port ]
+              [ NAS-Port-Id ]
+              [ NAS-Port-Type ]
+            * [ Class ]
+              [ Service-Type ]
+              [ Termination-Cause ]
+              [ Accounting-Input-Octets ]
+              [ Accounting-Input-Packets ]
+              [ Accounting-Output-Octets ]
+              [ Accounting-Output-Packets ]
+              [ Acct-Authentic ]
+              [ Accounting-Auth-Method ]
+              [ Acct-Link-Count ]
+              [ Acct-Session-Time ]
+              [ Acct-Tunnel-Connection ]
+              [ Acct-Tunnel-Packets-Lost ]
+              [ Callback-Id ]
+              [ Callback-Number ]
+              [ Called-Station-Id ]
+              [ Calling-Station-Id ]
+            * [ Connect-Info ]
+              [ Originating-Line-Info ]
+              [ Authorization-Lifetime ]
+              [ Session-Timeout ]
+              [ Idle-Timeout ]
+              [ Port-Limit ]
+              [ Accounting-Realtime-Required ]
+              [ Acct-Interim-Interval ]
+            * [ Filter-Id ]
+            * [ NAS-Filter-Rule ]
+            * [ QoS-Filter-Rule ]
+              [ Framed-Appletalk-Link ]
+              [ Framed-Appletalk-Network ]
+              [ Framed-Appletalk-Zone ]
+              [ Framed-Compression ]
+              [ Framed-Interface-Id ]
+              [ Framed-IP-Address ]
+              [ Framed-IP-Netmask ]
+            * [ Framed-IPv6-Prefix ]
+              [ Framed-IPv6-Pool ]
+            * [ Framed-IPv6-Route ]
+              [ Framed-IPX-Network ]
+              [ Framed-MTU ]
+              [ Framed-Pool ]
+              [ Framed-Protocol ]
+            * [ Framed-Route ]
+              [ Framed-Routing ]
+            * [ Login-IP-Host ]
+            * [ Login-IPv6-Host ]
+              [ Login-LAT-Group ]
+              [ Login-LAT-Node ]
+              [ Login-LAT-Port ]
+              [ Login-LAT-Service ]
+              [ Login-Service ]
+              [ Login-TCP-Port ]
+            * [ Tunneling ]
+            * [ Proxy-Info ]
+            * [ Route-Record ]
+            * [ AVP ]
+
+      ACA ::= <Diameter Header: 271, PXY>
+              < Session-Id >
+              { Result-Code }
+              { Origin-Host }
+              { Origin-Realm }
+              { Accounting-Record-Type }
+              { Accounting-Record-Number }
+              { Acct-Application-Id }
+              [ User-Name ]
+              [ Accounting-Sub-Session-Id ]
+              [ Acct-Session-Id ]
+              [ Acct-Multi-Session-Id ]
+              [ Event-Timestamp ]
+              [ Error-Message ]
+              [ Error-Reporting-Host ]
+            * [ Failed-AVP ]
+              [ Origin-AAA-Protocol ]
+              [ Origin-State-Id ]
+              [ NAS-Identifier ]
+              [ NAS-IP-Address ]
+              [ NAS-IPv6-Address ]
+              [ NAS-Port ]
+              [ NAS-Port-Id ]
+              [ NAS-Port-Type ]
+              [ Service-Type ]
+              [ Termination-Cause ]
+              [ Accounting-Realtime-Required ]
+              [ Acct-Interim-Interval ]
+            * [ Class ]
+            * [ Proxy-Info ]
+            * [ AVP ]
+
+@enum Service-Type
+
+   UNKNOWN                                            0
+   LOGIN                                              1
+   FRAMED                                             2
+   CALLBACK_LOGIN                                     3
+   CALLBACK_FRAMED                                    4
+   OUTBOUND                                           5
+   ADMINISTRATIVE                                     6
+   NAS_PROMPT                                         7
+   AUTHENTICATE_ONLY                                  8
+   CALLBACK_NAS_PROMPT                                9
+   CALL_CHECK                                         10
+   CALLBACK_ADMINISTRATIVE                            11
+   VOICE                                              12
+   FAX                                                13
+   MODEM_RELAY                                        14
+   IAPP_REGISTER                                      15
+   IAPP_AP_CHECK                                      16
+   AUTHORIZE_ONLY                                     17
+   FRAMED_MANAGEMENT                                  18
+
+@enum Framed-Protocol
+
+   PPP                                                1
+   SLIP                                               2
+   ARAP                                               3
+   GANDALF                                            4
+   XYLOGICS                                           5
+   X_75                                               6
+   GPRS_PDP_CONTEXT                                   7
+   ASCEND_ARA                                         255
+   MPP                                                256
+   EURAW                                              257
+   EUUI                                               258
+   X25                                                259
+   COMB                                               260
+   FR                                                 261
+
+@enum Framed-Routing
+
+   NONE                                               0
+   SEND_ROUTING_PACKETS                               1
+   LISTEN_FOR_ROUTING_PACKETS                         2
+   SEND_AND_LISTEN                                    3
+
+@enum Framed-Compression
+
+   NONE                                               0
+   IPX_HEADER_COMPRESSION                             2
+   STAC_LZS_COMPRESSION                               3
+
+@enum Login-Service
+
+   TELNET                                             0
+   RLOGIN                                             1
+   TCP_CLEAR                                          2
+   PORTMASTER                                         3
+   LAT                                                4
+   X25_PAD                                            5
+   X25_T3POS                                          6
+   UNASSIGNED                                         7
+
+@enum Acct-Authentic
+
+   NONE                                               0
+   RADIUS                                             1
+   LOCAL                                              2
+   REMOTE                                             3
+   DIAMETER                                           4
+
+@enum NAS-Port-Type
+
+   ASYNC                                              0
+   SYNC                                               1
+   ISDN_SYNC                                          2
+   ISDN_ASYNC_V120                                    3
+   ISDN_ASYNC_V110                                    4
+   VIRTUAL                                            5
+   PIAFS                                              6
+   HDLC_CLEAR_CHANNEL                                 7
+   X25                                                8
+   X75                                                9
+   G_3_FAX                                            10
+   SDSL_SYMMETRIC_DSL                                 11
+   IDSL_ISDN_DIGITAL_SUBSCRIBER_LINE                  14
+   ETHERNET                                           15
+   XDSL_DIGITAL_SUBSCRIBER_LINE_OF_UNKNOWN_TYPE       16
+   CABLE                                              17
+   WIRELESS_OTHER                                     18
+   WIRELESS_IEEE_802_11                               19
+   TOKEN_RING                                         20
+   FDDI                                               21
+   WIRELESS_CDMA2000                                  22
+   WIRELESS_UMTS                                      23
+   WIRELESS_1X_EV                                     24
+   IAPP                                               25
+   FTTP_FIBER_TO_THE_PREMISES                         26
+   WIRELESS_IEEE_802_16                               27
+   WIRELESS_IEEE_802_20                               28
+   WIRELESS_IEEE_802_22                               29
+   PPPOA_PPP_OVER_ATM                                 30
+   PPPOEOA_PPP_OVER_ETHERNET_OVER_ATM                 31
+   PPPOEOE_PPP_OVER_ETHERNET_OVER_ETHERNET            32
+   PPPOEOVLAN_PPP_OVER_ETHERNET_OVER_VLAN             33
+   PPPOEOQINQ_PPP_OVER_ETHERNET_OVER_IEEE_802_1QINQ   34
+   XPON_PASSIVE_OPTICAL_NETWORK                       35
+   WIRELESS_XGP                                       36
+
+@enum Tunnel-Type
+
+   PPTP                                               1
+   L2F                                                2
+   L2TP                                               3
+   ATMP                                               4
+   VTP                                                5
+   AH                                                 6
+   IP_IP_ENCAP                                        7
+   MIN_IP_IP                                          8
+   ESP                                                9
+   GRE                                                10
+   DVS                                                11
+   IP_IN_IP_TUNNELING                                 12
+   VLAN                                               13
+
+@enum Tunnel-Medium-Type
+
+   IPV4                                               1
+   IPV6                                               2
+   NSAP                                               3
+   HDLC                                               4
+   BBN                                                5
+   IEEE_802                                           6
+   E_163                                              7
+   E_164                                              8
+   F_69                                               9
+   X_121                                              10
+   IPX                                                11
+   APPLETALK_802                                      12
+   DECNET4                                            13
+   VINES                                              14
+   E_164_NSAP                                         15
+
+@enum Accounting-Auth-Method
+
+   PAP                                                1
+   CHAP                                               2
+   MS_CHAP_1                                          3
+   MS_CHAP_2                                          4
+   EAP                                                5
+   UNDEFINED                                          6
+   NONE                                               7
+
+@enum Origin-AAA-Protocol
+
+   RADIUS                                             1
+
+@grouped
+
+      Tunneling ::= <AVP Header: 401>
+                    { Tunnel-Type }
+                    { Tunnel-Medium-Type }
+                    { Tunnel-Client-Endpoint }
+                    { Tunnel-Server-Endpoint }
+                    [ Tunnel-Preference ]
+                    [ Tunnel-Client-Auth-Id ]
+                    [ Tunnel-Server-Auth-Id ]
+                    [ Tunnel-Assignment-Id ]
+                    [ Tunnel-Password ]
+                    [ Tunnel-Private-Group-Id ]

--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
 ]}.
 
 {minimum_otp_vsn, "19"}.
-{plugins, []}.
+{plugins, [rebar3_diameter_compiler]}.
 
 %% xref checks to run
 {xref_checks, [undefined_function_calls, undefined_functions,
@@ -17,3 +17,14 @@
 
 {cover_enabled, true}.
 {cover_export_enabled, true}.
+
+{provider_hooks,
+	[{pre,
+		[{compile, {diameter, compile}},
+		 {clean, {diameter, clean}}
+	]}
+]}.
+
+%% == Diameter compiler ==
+{dia_first_files, []}.
+{dia_opts, []}.

--- a/src/ergw_aaa.app.src
+++ b/src/ergw_aaa.app.src
@@ -10,7 +10,8 @@
                   sasl,
 		  lager,
 		  setup,
-		  eradius
+		  eradius,
+		  diameter
                  ]},
   {mod, { ergw_aaa_app, []}},
   {env, [

--- a/src/ergw_aaa_diameter.erl
+++ b/src/ergw_aaa_diameter.erl
@@ -1,0 +1,320 @@
+%% Copyright 2017, Travelping GmbH <info@travelping.com>
+
+%% This program is free software; you can redistribute it and/or
+%% modify it under the terms of the GNU General Public License
+%% as published by the Free Software Foundation; either version
+%% 2 of the License, or (at your option) any later version.
+
+-module(ergw_aaa_diameter).
+
+-behaviour(ergw_aaa).
+
+%% AAA API
+-export([validate_options/1, initialize_provider/1,
+         init/1, authorize/3, start_authentication/3, start_accounting/4]).
+%%
+%% diameter callbacks
+-export([peer_up/3,
+         peer_down/3,
+         pick_peer/4,
+         prepare_request/3,
+         prepare_retransmit/3,
+         handle_answer/4,
+         handle_error/4,
+         handle_request/3]).
+
+-export([stop/0, call/1, cast/1]).
+
+-include_lib("kernel/include/inet.hrl").
+-include_lib("diameter/include/diameter.hrl").
+-include("include/ergw_aaa_profile.hrl").
+-include("include/ergw_aaa_variable.hrl").
+-include("include/diameter_nasreq_rfc7155.hrl").
+
+-define(VENDOR_ID_3GPP, 10415).
+-define(VENDOR_ID_ETSI, 13019).
+-define(VENDOR_ID_TP,   18681).
+
+-define(Start, 2).
+-define(Interim, 3).
+-define(Stop, 4).
+
+-record(state, {accounting_record_number = 0,
+                sid    :: binary(), % diameter Session-Id
+                nas_id :: binary()}).
+
+-define(DefaultOptions, [{nas_identifier, undefined},
+                         {host, undefined},
+                         {realm, undefined},
+                         {connect_to, undefined}
+                        ]).
+
+%%===================================================================
+%% API
+%%===================================================================
+initialize_provider(Opts) ->
+    {OriginHost, Addr} = proplists:get_value(host, Opts),
+    OriginRealm = proplists:get_value(realm, Opts),
+    SvcOpts = [{'Origin-Host', OriginHost},
+               {'Origin-Realm', OriginRealm},
+               {'Origin-State-Id', diameter:origin_state_id()},
+               {'Host-IP-Address', [Addr]},
+               {'Vendor-Id', ?VENDOR_ID_TP},
+               {'Product-Name', "erGW-AAA"},
+               {'Supported-Vendor-Id', [?VENDOR_ID_3GPP,
+                                        ?VENDOR_ID_ETSI,
+                                        ?VENDOR_ID_TP]},
+               {'Auth-Application-Id', [diameter_nasreq_rfc7155:id()]},
+               {'Acct-Application-Id', [diameter_nasreq_rfc7155:id()]},
+               {string_decode, false},
+               {application, [{alias, nasreq},
+                              {dictionary, diameter_nasreq_rfc7155},
+                              {module, ?MODULE}]}],
+    ok = diameter:start_service(?MODULE, SvcOpts),
+
+    #diameter_uri{type = _AAA, % aaa | aaas
+                  fqdn = Host,
+                  port = Port,
+                  transport = Transport,
+                  protocol = _Diameter} = proplists:get_value(connect_to, Opts),
+    {ok, {Raddr, Type}} = resolve_hostname(Host),
+    TransportOpts = [{transport_module, transport_module(Transport)},
+                     {transport_config, [{reuseaddr, true},
+                                         {raddr, Raddr},
+                                         {rport, Port},
+                                         Type
+                                        ]}],
+    {ok, _} = diameter:add_transport(?MODULE, {connect, TransportOpts}),
+
+    {ok, []}.
+
+validate_options(Opts) ->
+    ergw_aaa_config:validate_options(fun validate_option/2, Opts, ?DefaultOptions).
+
+init(Opts) ->
+    State = #state{
+      sid = list_to_binary(string:join(diameter:session_id("erGW-AAA"), "")),
+      nas_id = proplists:get_value(nas_identifier, Opts)
+    },
+    {ok, State}.
+
+start_authentication(From, Session, State) ->
+    Verdict = success,
+    ?queue_event(From, {'AuthenticationRequestReply', {Verdict, Session, State}}),
+    {ok, State}.
+
+authorize(_From, _Session, State) ->
+    Verdict = success,
+    {reply, Verdict, ergw_aaa_session:to_session([]), State}.
+
+start_accounting(_From, 'Start', Session, State) ->
+    Request0 = create_ACR(Session, ?Start, State),
+    Request = Request0#diameter_nasreq_ACR{
+                'Accounting-Input-Octets' = [],
+                'Accounting-Input-Packets' = [],
+                'Accounting-Output-Octets' = [],
+                'Accounting-Output-Packets' = []
+              },
+    cast(Request),
+    {ok, inc_number(State)};
+
+start_accounting(_From, 'Interim', Session, State) ->
+    Request0 = create_ACR(Session, ?Interim, State),
+    Now = ergw_aaa_variable:now_ms(),
+    Start = ergw_aaa_session:attr_get('Accounting-Start', Session, Now),
+    Request = Request0#diameter_nasreq_ACR{
+                'Acct-Session-Time' = [round((Now - Start) / 1000)]
+              },
+    cast(Request),
+    {ok, inc_number(State)};
+
+start_accounting(_From, 'Stop', Session, State) ->
+    Request0 = create_ACR(Session, ?Stop, State),
+    Now = ergw_aaa_variable:now_ms(),
+    Start = ergw_aaa_session:attr_get('Accounting-Start', Session, Now),
+    Request = Request0#diameter_nasreq_ACR{
+                'Acct-Session-Time' = [round((Now - Start) / 1000)]
+              },
+    cast(Request),
+    {ok, inc_number(State)}.
+
+% will be used in tests
+stop() ->
+    diameter:stop_service(?MODULE),
+    diameter:remove_transport(?MODULE, true).
+
+call(Request) ->
+    diameter:call(?MODULE, nasreq, Request, []).
+
+cast(Request) ->
+    diameter:call(?MODULE, nasreq, Request, [detach]).
+
+%%===================================================================
+%% DIAMETER handler callbacks
+%%===================================================================
+
+peer_up(_SvcName, _Peer, State) ->
+    lager:debug("peer_up: ~p~n", [_Peer]),
+    State.
+
+peer_down(_SvcName, _Peer, State) ->
+    lager:debug("peer_down: ~p~n", [_Peer]),
+    State.
+
+pick_peer([Peer | _], _, _SvcName, _State) ->
+    lager:debug("pick_peer: ~p~n", [Peer]),
+    {ok, Peer}.
+
+prepare_request(#diameter_packet{msg = #diameter_nasreq_ACR{} = Rec}, _, {_, Caps}) ->
+    #diameter_caps{origin_host = {OH, DH},
+                   origin_realm = {OR, DR},
+                   acct_application_id = {[Ids], _}}
+        = Caps,
+
+    {send, Rec#diameter_nasreq_ACR{'Origin-Host' = OH,
+                                   'Origin-Realm' = OR,
+                                   'Destination-Host' = [DH],
+                                   'Destination-Realm' = DR,
+                                   'Acct-Application-Id' = Ids}};
+
+prepare_request(_Packet, _, _Peer) ->
+    lager:debug("unexpected request: ~p~n", [_Packet]),
+    erlang:error({unexpected, ?MODULE, ?LINE}).
+
+prepare_retransmit(Packet, SvcName, Peer) ->
+    prepare_request(Packet, SvcName, Peer).
+
+handle_answer(#diameter_packet{msg = Msg}, _Request, _SvcName, _Peer) ->
+    {ok, Msg}.
+
+handle_error(Reason, _Request, _SvcName, _Peer) ->
+    {error, Reason}.
+
+handle_request(_Packet, _SvcName, _Peer) ->
+    erlang:error({unexpected, ?MODULE, ?LINE}).
+
+
+%%===================================================================
+%% internal helpers
+%%===================================================================
+validate_option(nas_identifier, Value) when is_binary(Value) ->
+    Value;
+validate_option(connect_to = Opt, Value) when is_binary(Value) ->
+    try
+        #diameter_uri{} = diameter_types:'DiameterURI'(decode, Value)
+    catch _:_ -> validate_option_error(Opt, Value)
+    end;
+validate_option(host = Opt, Value) when is_binary(Value) ->
+    try
+        {ok, {Addr, _Type}} = resolve_hostname(Value),
+        {Value, Addr}
+    catch _:_ -> validate_option_error(Opt, Value)
+    end;
+validate_option(realm, Value) when is_binary(Value) ->
+    Value;
+validate_option(Opt, Value) ->
+    validate_option_error(Opt, Value).
+
+validate_option_error(Opt, Value) ->
+    throw({error, {options, {Opt, Value}}}).
+
+inc_number(#state{accounting_record_number = Number} = State) ->
+    State#state{accounting_record_number = Number + 1}.
+
+attr_get(Key, Session) ->
+    case ergw_aaa_session:attr_get(Key, Session, undefined) of
+       undefined -> [];
+       Value -> [Value]
+    end.
+
+resolve_hostname(Name) when is_binary(Name) -> resolve_hostname(binary_to_list(Name));
+resolve_hostname(Name) ->
+    Name1 = case inet:gethostbyname(Name, inet6) of
+        {error, nxdomain} -> inet:gethostbyname(Name, inet);
+        Other -> Other
+    end,
+    case Name1 of
+        {ok, #hostent{h_addr_list = [LocalIP | _], h_addrtype = Type}} ->
+            {ok, {LocalIP, Type}};
+        _ -> erlang:error(badarg, Name)
+    end.
+
+transport_module(tcp) -> diameter_tcp;
+transport_module(sctp) -> diameter_sctp;
+transport_module(_) -> unknown.
+
+service_type([Atom]) when is_atom(Atom) -> service_type(Atom);
+service_type('Login-User')              -> ?'DIAMETER_NASREQ_SERVICE-TYPE_LOGIN';
+service_type('Framed-User')             -> ?'DIAMETER_NASREQ_SERVICE-TYPE_FRAMED';
+service_type('Callback-Login-User')     -> ?'DIAMETER_NASREQ_SERVICE-TYPE_CALLBACK_LOGIN';
+service_type('Callback-Framed-User')    -> ?'DIAMETER_NASREQ_SERVICE-TYPE_CALLBACK_FRAMED';
+service_type('Outbound-User')           -> ?'DIAMETER_NASREQ_SERVICE-TYPE_OUTBOUND';
+service_type('Administrative-User')     -> ?'DIAMETER_NASREQ_SERVICE-TYPE_ADMINISTRATIVE';
+service_type('NAS-Prompt-User')         -> ?'DIAMETER_NASREQ_SERVICE-TYPE_NAS_PROMPT';
+service_type('Authenticate-Only')       -> ?'DIAMETER_NASREQ_SERVICE-TYPE_AUTHENTICATE_ONLY';
+service_type('Callback-NAS-Prompt')     -> ?'DIAMETER_NASREQ_SERVICE-TYPE_CALLBACK_NAS_PROMPT';
+service_type('Call-Check')              -> ?'DIAMETER_NASREQ_SERVICE-TYPE_CALL_CHECK';
+service_type('Callback-Administrative') -> ?'DIAMETER_NASREQ_SERVICE-TYPE_CALLBACK_ADMINISTRATIVE';
+service_type('Voice')                   -> ?'DIAMETER_NASREQ_SERVICE-TYPE_VOICE';
+service_type('Fax')                     -> ?'DIAMETER_NASREQ_SERVICE-TYPE_FAX';
+service_type('Modem-Relay')             -> ?'DIAMETER_NASREQ_SERVICE-TYPE_MODEM_RELAY';
+service_type('IAPP-Register')           -> ?'DIAMETER_NASREQ_SERVICE-TYPE_IAPP_REGISTER';
+service_type('IAPP-AP-Check')           -> ?'DIAMETER_NASREQ_SERVICE-TYPE_IAPP_AP_CHECK';
+service_type('Authorze-Only')           -> ?'DIAMETER_NASREQ_SERVICE-TYPE_AUTHORIZE_ONLY';
+service_type('Framed-Management')       -> ?'DIAMETER_NASREQ_SERVICE-TYPE_FRAMED_MANAGEMENT';
+% these types are not described in dia file
+%service_type('TP-CAPWAP-WTP')           -> ?'DIAMETER_NASREQ_SERVICE-TYPE_UNKNOWN'.
+%service_type('TP-CAPWAP-STA')           -> ?'DIAMETER_NASREQ_SERVICE-TYPE_UNKNOWN'.
+service_type(_)                         -> ?'DIAMETER_NASREQ_SERVICE-TYPE_UNKNOWN'.
+
+acct_authentic([Atom]) when is_atom(Atom) -> acct_authentic(Atom);
+acct_authentic('None')                    -> ?'DIAMETER_NASREQ_ACCT-AUTHENTIC_NONE';
+acct_authentic('RADIUS')                  -> ?'DIAMETER_NASREQ_ACCT-AUTHENTIC_RADIUS';
+acct_authentic('Local')                   -> ?'DIAMETER_NASREQ_ACCT-AUTHENTIC_LOCAL';
+acct_authentic('Remote')                  -> ?'DIAMETER_NASREQ_ACCT-AUTHENTIC_REMOTE';
+acct_authentic('Diameter')                -> ?'DIAMETER_NASREQ_ACCT-AUTHENTIC_DIAMETER';
+acct_authentic(_)                         -> ?'DIAMETER_NASREQ_ACCT-AUTHENTIC_NONE'.
+
+framed_protocol([Atom]) when is_atom(Atom) -> framed_protocol(Atom);
+framed_protocol('PPP')                     -> ?'DIAMETER_NASREQ_FRAMED-PROTOCOL_PPP';
+framed_protocol('SLIP')                    -> ?'DIAMETER_NASREQ_FRAMED-PROTOCOL_SLIP';
+framed_protocol('ARAP')                    -> ?'DIAMETER_NASREQ_FRAMED-PROTOCOL_ARAP';
+framed_protocol('Gandalf-SLML')            -> ?'DIAMETER_NASREQ_FRAMED-PROTOCOL_GANDALF';
+framed_protocol('Xylogics-IPX-SLIP')       -> ?'DIAMETER_NASREQ_FRAMED-PROTOCOL_XYLOGICS';
+framed_protocol('X.75-Synchronous')        -> ?'DIAMETER_NASREQ_FRAMED-PROTOCOL_X_75';
+framed_protocol('GPRS-PDP-Context')        -> ?'DIAMETER_NASREQ_FRAMED-PROTOCOL_GPRS_PDP_CONTEXT';
+% note that mapping for 255,256,257,258,259,260,261 missed for now
+% these types are not described in dia file
+%framed_protocol('TP-CAPWAP')               -> ?'DIAMETER_NASREQ_FRAMED-PROTOCOL_PPP'.
+framed_protocol(_)                         -> ?'DIAMETER_NASREQ_FRAMED-PROTOCOL_PPP'.
+
+create_ACR(Session, Type, State) ->
+    AcctSessionId = hd(attr_get('Session-Id', Session)),
+    MultiSessionId = hd(attr_get('Multi-Session-Id', Session)),
+    #diameter_nasreq_ACR{
+       'Session-Id' = State#state.sid,
+       'Accounting-Record-Type' = Type,
+       'Accounting-Record-Number' = State#state.accounting_record_number,
+       'User-Name' = attr_get('Username', Session),
+       'Acct-Session-Id' = io_lib:format("~40.16.0B", [AcctSessionId]),
+       'Acct-Multi-Session-Id' = io_lib:format("~40.16.0B", [MultiSessionId]),
+       'NAS-Identifier' = [State#state.nas_id],
+       'NAS-Port-Id' = attr_get('Port-Id', Session),
+       'NAS-Port-Type' = attr_get('Port-Type', Session),
+       'Class' = attr_get('Class', Session),
+       'Service-Type' = [service_type(attr_get('Service-Type', Session))],
+       'Accounting-Input-Octets' = attr_get('InOctets', Session),
+       'Accounting-Input-Packets' = attr_get('InPackets', Session),
+       'Accounting-Output-Octets' = attr_get('OutOctets', Session),
+       'Accounting-Output-Packets' = attr_get('OutPackets', Session),
+       'Acct-Authentic' = [acct_authentic(attr_get('Acct-Authentic', Session))],
+       'Called-Station-Id' = attr_get('Called-Station-Id', Session),
+       'Calling-Station-Id' = attr_get('Calling-Station-Id', Session),
+       'Framed-Interface-Id' = attr_get('Framed-Interface-Id', Session),
+       'Framed-IP-Address' = attr_get('Framed-IP-Address', Session),
+       'Framed-Protocol' = [framed_protocol(attr_get('Framed-Protocol', Session))],
+       'Tunneling' = tunneling(Session, State),
+       'AVP' = []}.
+
+% TODO: build #'Tunneling'{}
+tunneling(_Session, _State) -> [].

--- a/test/config_SUITE.erl
+++ b/test/config_SUITE.erl
@@ -26,6 +26,15 @@
 -define(RADIUS_CFG(Key, Value),
 	lists:keystore(Key, 1, ?RADIUS_OK_CFG, {Key, Value})).
 
+-define(DIAMETER_OK_CFG,
+	[{nas_identifier,<<"NAS-Identifier">>},
+	 {host, <<"127.0.0.1">>},
+	 {realm, <<"example.com">>},
+	 {connect_to, <<"aaa://127.0.0.1:3868">>}]).
+
+-define(DIAMETER_CFG(Key, Value),
+	lists:keystore(Key, 1, ?DIAMETER_OK_CFG, {Key, Value})).
+
 %%%===================================================================
 %%% API
 %%%===================================================================
@@ -58,5 +67,16 @@ config(_Config)  ->
 
     ?ok_option([{ergw_aaa_provider, {ergw_aaa_radius, ?RADIUS_OK_CFG}}]),
     ?ok_option([{ergw_aaa_provider, {ergw_aaa_radius, ?RADIUS_CFG(radius_acct_server, {"localhost",1812,<<"secret">>})}}]),
+
+    ?error_option([{ergw_aaa_provider, {ergw_aaa_diameter, []}}]),
+    ?error_option([{ergw_aaa_provider, {ergw_aaa_diameter, [{invalid_option, []} | ?DIAMETER_OK_CFG]}}]),
+    ?error_option([{ergw_aaa_provider, {ergw_aaa_diameter, ?DIAMETER_CFG(nas_identifier, invalid_id)}}]),
+    ?error_option([{ergw_aaa_provider, {ergw_aaa_diameter, ?DIAMETER_CFG(host, invalid_host)}}]),
+    ?error_option([{ergw_aaa_provider, {ergw_aaa_diameter, ?DIAMETER_CFG(realm, invalid_realm)}}]),
+    ?error_option([{ergw_aaa_provider, {ergw_aaa_diameter, ?DIAMETER_CFG(connect_to, invalid_uri)}}]),
+    ?error_option([{ergw_aaa_provider, {ergw_aaa_diameter, ?DIAMETER_CFG(host, <<"undefined.example.net">>)}}]),
+    ?error_option([{ergw_aaa_provider, {ergw_aaa_diameter, ?DIAMETER_CFG(connect_to, <<"http://example.com:12345">>)}}]),
+
+    ?ok_option([{ergw_aaa_provider, {ergw_aaa_diameter, ?DIAMETER_OK_CFG}}]),
 
     ok.

--- a/test/diameter_SUITE.erl
+++ b/test/diameter_SUITE.erl
@@ -1,0 +1,78 @@
+%% Copyright 2017, Travelping GmbH <info@travelping.com>
+
+%% This program is free software; you can redistribute it and/or
+%% modify it under the terms of the GNU General Public License
+%% as published by the Free Software Foundation; either version
+%% 2 of the License, or (at your option) any later version.
+
+-module(diameter_SUITE).
+
+%% Common Test callbacks
+-export([all/0,
+         init_per_suite/1,
+         end_per_suite/1]).
+
+%% Test cases
+-export([check_CER_CEA/1, accounting/1]).
+
+-include_lib("common_test/include/ct.hrl").
+
+%%%===================================================================
+%%% Common Test callbacks
+%%%===================================================================
+
+all() ->
+    [check_CER_CEA,
+     accounting].
+
+
+init_per_suite(Config) ->
+    Opts = [{nas_identifier, <<"NAS">>},
+            {host, <<"127.0.0.1">>},
+            {realm, <<"example.com">>},
+            {connect_to, <<"aaa://127.0.0.1:3868">>}
+           ],
+    application:load(ergw_aaa),
+    application:set_env(ergw_aaa, ergw_aaa_provider, {ergw_aaa_diameter, Opts}),
+
+    diameter_test_server:start(),
+    application:ensure_all_started(ergw_aaa),
+
+    timer:sleep(100),
+    Config.
+
+end_per_suite(_Config) ->
+    application:stop(ergw_aaa),
+    application:unload(ergw_aaa),
+    diameter_test_server:stop(),
+    ok.
+
+%%%===================================================================
+%%% Test cases
+%%%===================================================================
+
+check_CER_CEA(_Config) ->
+    Statistics = get_stats(),
+    % check that client has sent CER
+    1 = proplists:get_value({{0, 257, 1}, send}, Statistics),
+    % check that client has received CEA
+    1 = proplists:get_value({{0, 257, 0}, recv}, Statistics),
+    ok.
+
+accounting(_Config) ->
+    {ok, Session} = ergw_aaa_session_sup:new_session(self(), #{}),
+    success = ergw_aaa_session:authenticate(Session, #{}),
+    ergw_aaa_session:start(Session, #{}),
+
+    timer:sleep(100),
+    Statistics = get_stats(),
+
+    % check that client has sent ACR
+    1 = proplists:get_value({{1, 271, 1}, send}, Statistics),
+    % check that client has received ACA
+    %1 = proplists:get_value({{1, 271, 0}, recv}, Statistics),
+    ok.
+
+get_stats() ->
+    [Transport] = diameter:service_info(ergw_aaa_diameter, transport),
+    proplists:get_value(statistics, Transport).

--- a/test/diameter_test_server.erl
+++ b/test/diameter_test_server.erl
@@ -1,0 +1,80 @@
+%% Copyright 2017, Travelping GmbH <info@travelping.com>
+
+%% This program is free software; you can redistribute it and/or
+%% modify it under the terms of the GNU General Public License
+%% as published by the Free Software Foundation; either version
+%% 2 of the License, or (at your option) any later version.
+
+-module(diameter_test_server).
+
+-include_lib("diameter/include/diameter.hrl").
+-include("../include/diameter_nasreq_rfc7155.hrl").
+
+-export([start/0, stop/0]).
+
+%% diameter callbacks
+-export([peer_up/3,
+         peer_down/3,
+         pick_peer/4,
+         prepare_request/3,
+         prepare_retransmit/3,
+         handle_answer/4,
+         handle_error/4,
+         handle_request/3]).
+
+-define(UNEXPECTED, erlang:error({unexpected, ?MODULE, ?LINE})).
+
+
+%%===================================================================
+%% API
+%%===================================================================
+
+start() ->
+    application:ensure_all_started(diameter),
+    SvcOpts = [{'Origin-Host', "server.example.com"},
+               {'Origin-Realm', "example.com"},
+               {'Vendor-Id', 193},
+               {'Product-Name', "Server"},
+               {'Auth-Application-Id', [1]},
+               {restrict_connections, false},
+               {string_decode, false},
+               {application, [{alias, nasreq},
+                              {dictionary, diameter_nasreq_rfc7155},
+                              {module, ?MODULE}]}],
+    diameter:start_service(?MODULE, SvcOpts),
+    Opts = [{transport_module, diameter_tcp},
+            {transport_config, [{reuseaddr, true},
+                                {ip, {127,0,0,1}},
+                                {port, 3868}]}],
+    diameter:add_transport(?MODULE, {listen, Opts}).
+
+stop() ->
+    diameter:stop_service(?MODULE).
+
+%%===================================================================
+%% DIAMETER handler callbacks
+%%===================================================================
+
+peer_up(_SvcName, _Peer, State) ->
+    State.
+
+peer_down(_SvcName, _Peer, State) ->
+    State.
+
+pick_peer(_, _, _SvcName, _State) ->
+    ?UNEXPECTED.
+
+prepare_request(_, _SvcName, _Peer) ->
+    ?UNEXPECTED.
+
+prepare_retransmit(_Packet, _SvcName, _Peer) ->
+    ?UNEXPECTED.
+
+handle_answer(_Packet, _Request, _SvcName, _Peer) ->
+    ?UNEXPECTED.
+
+handle_error(_Reason, _Request, _SvcName, _Peer) ->
+    ?UNEXPECTED.
+
+handle_request(#diameter_packet{msg = _Msg}, _SvcName, _) ->
+    {answer_message, 3001}.  %% DIAMETER_COMMAND_UNSUPPORTED


### PR DESCRIPTION
This PR adds an initial version of Diameter client to send Accounting data according to RFC 7155.

Example of diameter provider configuration:
```
{ergw_aaa_provider,
    {ergw_aaa_diameter,
        [{nas_identifier, <<"nas01.example.com">>},
         {host,    <<"example.com">>}},
         {realm,   <<"client.example.com">>}},
         {connect_to,     <<"aaa://10.10.10.10:3868">>}}
        ]}
```