### PR TITLE
restrict option validation in top level to out own settings

### DIFF
--- a/src/ergw_aaa_config.erl
+++ b/src/ergw_aaa_config.erl
@@ -45,5 +45,8 @@ validate_option(ergw_aaa_provider, {Handler, Opts} = Value)
 	    throw({error, {options, Value}})
     end,
     {Handler, Handler:validate_options(Opts)};
-validate_option(Opt, Value) ->
-    throw({error, {options, {Opt, Value}}}).
+validate_option(Opt, Value)
+  when Opt == ergw_aaa_provider ->
+    throw({error, {options, {Opt, Value}}});
+validate_option(_Opt, Value) ->
+    Value.

--- a/test/config_SUITE.erl
+++ b/test/config_SUITE.erl
@@ -16,7 +16,7 @@
 	?match({error,{options, _}}, (catch ergw_aaa_config:load_config(Config)))).
 
 -define(ok_option(Config),
-	?match([_], ergw_aaa_config:load_config(Config))).
+	?match([_|_], ergw_aaa_config:load_config(Config))).
 
 -define(RADIUS_OK_CFG,
 	[{nas_identifier,<<"NAS-Identifier">>},
@@ -36,7 +36,8 @@ all() ->
 config() ->
     [{doc, "Test the config validation"}].
 config(_Config)  ->
-    ?error_option([{invalid_option, []}]),
+    ?ok_option([{vsn, "1.0.0"}]),
+
     ?error_option([{ergw_aaa_provider, invalid_option}]),
     ?error_option([{ergw_aaa_provider, {invalid_handler, []}}]),
 


### PR DESCRIPTION
The application environement contains more than our own
config settings. Restrict validation (especially failure) to
our defined config settings.