### PR TITLE
OTP 20 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ otp_release:
  - 19.1
  - 19.2
  - 19.3
+ - 20.0
 
 install: "true"
 

--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ Using rebar3:
 [travis badge]: https://img.shields.io/travis/travelping/ergw_aaa/master.svg?style=flat-square
 [coveralls]: https://coveralls.io/github/travelping/ergw_aaa
 [coveralls badge]: https://img.shields.io/coveralls/travelping/ergw_aaa/master.svg?style=flat-square
-[erlang version badge]: https://img.shields.io/badge/erlang-R19.1%20to%2019.3-blue.svg?style=flat-square
+[erlang version badge]: https://img.shields.io/badge/erlang-R19.1%20to%2020.0-blue.svg?style=flat-square

--- a/src/ergw_aaa_diameter.erl
+++ b/src/ergw_aaa_diameter.erl
@@ -201,7 +201,7 @@ validate_option(nas_identifier, Value) when is_binary(Value) ->
     Value;
 validate_option(connect_to = Opt, Value) when is_binary(Value) ->
     try
-        #diameter_uri{} = diameter_types:'DiameterURI'(decode, Value)
+        #diameter_uri{} = decode_diameter_uri(Value)
     catch _:_ -> validate_option_error(Opt, Value)
     end;
 validate_option(host = Opt, Value) when is_binary(Value) ->
@@ -217,6 +217,13 @@ validate_option(Opt, Value) ->
 
 validate_option_error(Opt, Value) ->
     throw({error, {options, {Opt, Value}}}).
+
+decode_diameter_uri(Value) ->
+    Module = diameter_types, % trick to stop xref complains about undef function
+    try
+        apply(Module, 'DiameterURI', [decode, Value, #{rfc => 6733}]) % OTP 20
+    catch _:_ -> apply(Module, 'DiameterURI', [decode, Value])
+    end.
 
 inc_number(#state{accounting_record_number = Number} = State) ->
     State#state{accounting_record_number = Number + 1}.

--- a/src/ergw_aaa_session_seq.erl
+++ b/src/ergw_aaa_session_seq.erl
@@ -65,5 +65,5 @@ code_change(_OldVsn, State, _Extra) ->
 %%%===================================================================
 
 new_id(Id) ->
-    Start = (crypto:rand_uniform(0, 4294967296)) bsl 128,
+    Start = (rand:uniform(4294967296) - 1) bsl 128,
     ets:insert(?MODULE, {Id, Start}).


### PR DESCRIPTION
* Use `rand:uniform/1` instead of deprecated `crypto:rand_uniform/2` to make `xref` happy
* OTP 20 has diameter application version 2.0 and here we need a small change for using non-pulbic `diameter_types:'DiameterURI'` function. 