### PR TITLE
Fix formatting of some 3GPP attributes in Diameter provider

### DIFF
--- a/src/ergw_aaa_diameter.erl
+++ b/src/ergw_aaa_diameter.erl
@@ -345,6 +345,13 @@ format_cc(Value) when is_binary(Value) ->
                              || <<X>> <= Value]);
 format_cc(_) -> [].
 
+octet_string([Int]) when is_integer(Int) -> [<<Int>>];
+octet_string([{A, B}]) when is_integer(A), is_integer(B) -> [<<A, B>>];
+octet_string(OctetString) -> OctetString.
+
+int_to_binary([Int]) when is_integer(Int) -> [erlang:integer_to_binary(Int)];
+int_to_binary(Binary) -> Binary.
+
 create_ACR(Session, Type, State) ->
     AcctSessionId = hd(attr_get('Session-Id', Session)),
     MultiSessionId = hd(attr_get('Multi-Session-Id', Session)),
@@ -373,24 +380,24 @@ create_ACR(Session, Type, State) ->
        'Tunneling' = tunneling(Session, State),
        '3GPP-IMSI' = attr_get('3GPP-IMSI', Session),
        '3GPP-Charging-Id' = attr_get('3GPP-Charging-ID', Session),
-       '3GPP-PDP-Type' = [pdp_type(attr_get('3GPP-Charging-ID', Session))],
+       '3GPP-PDP-Type' = [pdp_type(attr_get('3GPP-PDP-Type', Session))],
        '3GPP-CG-Address' = attr_get_addr('3GPP-Charging-Gateway-Address', Session),
        '3GPP-GPRS-Negotiated-QoS-Profile' = attr_get('3GPP-GPRS-Negotiated-QoS-Profile', Session),
        '3GPP-SGSN-Address' = attr_get_addr('3GPP-SGSN-Address', Session),
        '3GPP-GGSN-Address' = attr_get_addr('3GPP-GGSN-Address', Session),
        '3GPP-IMSI-MCC-MNC' = attr_get('3GPP-IMSI-MCC-MNC', Session),
        '3GPP-GGSN-MCC-MNC' = attr_get('3GPP-GGSN-MCC-MNC', Session),
-       '3GPP-NSAPI' = attr_get('3GPP-NSAPI', Session),
-       '3GPP-Selection-Mode' = attr_get('3GPP-Selection-Mode', Session),
+       '3GPP-NSAPI' = octet_string(attr_get('3GPP-NSAPI', Session)),
+       '3GPP-Selection-Mode' = int_to_binary(attr_get('3GPP-Selection-Mode', Session)),
        '3GPP-Charging-Characteristics' = format_cc(attr_get('3GPP-Charging-Characteristics', Session)),
        '3GPP-CG-IPv6-Address' = attr_get_addr('3GPP-Charging-Gateway-IPv6-Address', Session),
        '3GPP-SGSN-IPv6-Address' = attr_get_addr('3GPP-SGSN-IPv6-Address', Session),
        '3GPP-GGSN-IPv6-Address' = attr_get_addr('3GPP-GGSN-IPv6-Address', Session),
        '3GPP-SGSN-MCC-MNC' = attr_get('3GPP-SGSN-MCC-MNC', Session),
        '3GPP-IMEISV' = attr_get('3GPP-IMEISV', Session),
-       '3GPP-RAT-Type' = attr_get('3GPP-RAT-Type', Session),
+       '3GPP-RAT-Type' = octet_string(attr_get('3GPP-RAT-Type', Session)),
        '3GPP-User-Location-Info' = attr_get('3GPP-User-Location-Info', Session),
-       '3GPP-MS-TimeZone' = attr_get('3GPP-MS-TimeZone', Session),
+       '3GPP-MS-TimeZone' = octet_string(attr_get('3GPP-MS-TimeZone', Session)),
        '3GPP-CAMEL-Charging-Info' = attr_get('3GPP-Camel-Charging', Session),
        '3GPP-Packet-Filter' = attr_get('3GPP-Packet-Filter', Session),
        '3GPP-Negotiated-DSCP' = attr_get('3GPP-Negotiated-DSCP', Session),

--- a/test/diameter_SUITE.erl
+++ b/test/diameter_SUITE.erl
@@ -102,17 +102,31 @@ acct_interim_interval(_Config) ->
 
 attrs_3gpp(_Config) ->
     Attrs = #{
+      '3GPP-GGSN-Address'       => {199,255,4,125},
+      '3GPP-IMEISV'             => <<82,21,50,96,32,80,30,0>>,
       '3GPP-IMSI'               => <<"250071234567890">>,
       '3GPP-Charging-ID'        => <<214, 208, 226, 238>>,
-      '3GPP-PDP-Type'           => 'PPP',
-      '3GPP-SGSN-Address'       => {10, 10, 10, 10},
-      '3GPP-IMSI-MCC-MNC'       => <<"250999">>,
-      '3GPP-GGSN-MCC-MNC'       => <<"250888">>,
+      '3GPP-IMSI-MCC-MNC'       => <<"25999">>,
+      '3GPP-GGSN-MCC-MNC'       => <<"25888">>,
+      '3GPP-MS-TimeZone'        => {128,1},
+      '3GPP-NSAPI'              => 5,
+      '3GPP-PDP-Type'           => 'IPv4',
+      '3GPP-RAT-Type'           => 6,
+      '3GPP-SGSN-Address'       => <<192,168,1,1>>,
+      '3GPP-SGSN-MCC-MNC'       => <<"26201">>,
       '3GPP-SGSN-IPv6-Address'  => {100, 10, 10, 10},
       '3GPP-GGSN-IPv6-Address'  => {200, 10, 10, 10},
-      '3GPP-SGSN-MCC-MNC'       => <<"250777">>,
-      '3GPP-IMEISV'             => <<"3566190531472414">>,
-      '3GPP-RAT-Type'           => <<1>>
+      '3GPP-Selection-Mode'     => 0,
+      '3GPP-User-Location-Info' => <<24,98,242,16,64,163,98,242,16,1,156,232,0>>,
+      'Called-Station-Id'       => <<"some.station.gprs">>,
+      'Calling-Station-Id'      => <<"543148000012345">>,
+      'Framed-IP-Address'       => {0,0,0,0},
+      'Framed-Protocol'         => 'GPRS-PDP-Context',
+      'Multi-Session-Id'        => 1012552258277823040188863251876666193415858290601,
+      'Password'                => <<"ergw">>,
+      'Service-Type'            => 'Framed-User',
+      'Session-Id'              => 1012552258277823040188863251876666193415858290601,
+      'Username'                => <<"ergw">>
      },
 
     Count0 = proplists:get_value({{1, 271, 0}, recv, {'Result-Code',2001}}, get_stats()),

--- a/test/diameter_test_server.erl
+++ b/test/diameter_test_server.erl
@@ -103,15 +103,16 @@ handle_request(#diameter_packet{msg = _Msg}, _SvcName, _) ->
 check_3gpp(Msg, ACA) ->
     Success = [<<"250071234567890">>] == Msg#diameter_sgi_ACR.'3GPP-IMSI'
         andalso [<<214, 208, 226, 238>>] == Msg#diameter_sgi_ACR.'3GPP-Charging-Id'
-        andalso [1] == Msg#diameter_sgi_ACR.'3GPP-PDP-Type'
-        andalso [<<10, 10, 10, 10>>] == Msg#diameter_sgi_ACR.'3GPP-SGSN-Address'
-        andalso [<<"250999">>] == Msg#diameter_sgi_ACR.'3GPP-IMSI-MCC-MNC'
-        andalso [<<"250888">>] == Msg#diameter_sgi_ACR.'3GPP-GGSN-MCC-MNC'
+        andalso [0] == Msg#diameter_sgi_ACR.'3GPP-PDP-Type'
+        andalso [<<192, 168, 1, 1>>] == Msg#diameter_sgi_ACR.'3GPP-SGSN-Address'
+        andalso [<<"25999">>] == Msg#diameter_sgi_ACR.'3GPP-IMSI-MCC-MNC'
+        andalso [<<"25888">>] == Msg#diameter_sgi_ACR.'3GPP-GGSN-MCC-MNC'
         andalso [<<100, 10, 10, 10>>] == Msg#diameter_sgi_ACR.'3GPP-SGSN-IPv6-Address'
         andalso [<<200, 10, 10, 10>>] == Msg#diameter_sgi_ACR.'3GPP-GGSN-IPv6-Address'
-        andalso [<<"250777">>] == Msg#diameter_sgi_ACR.'3GPP-SGSN-MCC-MNC'
-        andalso [<<"3566190531472414">>] == Msg#diameter_sgi_ACR.'3GPP-IMEISV'
-        andalso [<<1>>] == Msg#diameter_sgi_ACR.'3GPP-RAT-Type',
+        andalso [<<"26201">>] == Msg#diameter_sgi_ACR.'3GPP-SGSN-MCC-MNC'
+        andalso [<<82,21,50,96,32,80,30,0>>] == Msg#diameter_sgi_ACR.'3GPP-IMEISV'
+        andalso [<<5>>] == Msg#diameter_sgi_ACR.'3GPP-NSAPI'
+        andalso [<<6>>] == Msg#diameter_sgi_ACR.'3GPP-RAT-Type',
     if Success == true -> {reply, ACA};
        true -> {answer_message, 3001}
     end.


### PR DESCRIPTION
The following attributes are fixed:

* 3GPP-RAT-Type
* 3GPP-NSAPI
* 3GPP-MS-TimeZone
* 3GPP-Selection-Mode
* 3GPP-PDP-Type