### PR TITLE
Don't fill Acct-Session-Id and Acct-Multi-Session-Id in Diameter

### DIFF
--- a/src/ergw_aaa_diameter.erl
+++ b/src/ergw_aaa_diameter.erl
@@ -331,10 +331,6 @@ to_list(Avps) when is_map(Avps) ->
 to_list(Avp) ->
     Avp.
 
-from_session('Session-Id', Value, M) ->
-    M#{'Acct-Session-Id' =>  io_lib:format("~40.16.0B", [Value])};
-from_session('Multi-Session-Id', Value, M) ->
-    M#{'Acct-Multi-Session-Id' =>  io_lib:format("~40.16.0B", [Value])};
 from_session('Service-Type' = Key, Value, M) ->
     M#{Key => [service_type(Value)]};
 from_session('Acct-Authentic' = Key, Value, M) ->


### PR DESCRIPTION
provider

According RFC 6733:

```
9.8.4.  Acct-Session-Id AVP
...
is of type OctetString is only used when RADIUS/Diameter translation
occurs. This AVP contains the contents of the RADIUS Acct-Session-Id
attribute.
```

There is no RADIUS/Diameter translation in AAA session logic now.

```
9.8.5.  Acct-Multi-Session-Id AVP
...
This AVP MAY be returned by the Diameter server in an authorization
answer, and it MUST be used in all accounting messages for the given
session.
```

Right now we don't have this step then `Acct-Multi-Session-id` may be ignored.