### PR TITLE
Fix errors when config doesn't contain all application settings.

### DIFF
--- a/src/ergw_aaa_profile.erl
+++ b/src/ergw_aaa_profile.erl
@@ -104,8 +104,10 @@ init_provider(State) ->
 get_application_opts(ApplicationID) ->
     case setup:get_env(ergw_aaa, applications) of
         {ok, Providers} when is_list(Providers) ->
-            AppOpts = lists:keyfind(ApplicationID, 1, Providers),
-            get_opts(AppOpts);
+            case lists:keyfind(ApplicationID, 1, Providers) of
+                false   -> get_opts(lists:keyfind(default, 1, Providers));
+                AppOpts -> get_opts(AppOpts)
+            end;
         _ ->
             get_old_application_opts()
     end.

--- a/src/ergw_aaa_session_seq.erl
+++ b/src/ergw_aaa_session_seq.erl
@@ -30,8 +30,16 @@ start_link() ->
 new(Id) ->
     gen_server:call(?SERVER, {new, Id}).
 
+inc(Id = default) ->
+    ets:update_counter(?MODULE, Id, 1);
 inc(Id) ->
-    ets:update_counter(?MODULE, Id, 1).
+    try
+        ets:update_counter(?MODULE, Id, 1)
+    catch
+        _:badarg ->
+            new_id(Id),
+            ets:update_counter(?MODULE, Id, 1)
+    end.
 
 %%%===================================================================
 %%% gen_server callbacks


### PR DESCRIPTION
Fetch default setting if specified application_id setting isn't found.
Create ets for seq if it doesn't exist.