### PR TITLE
make Interim-Accounting and other session options non-required

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,10 @@ Example of possible config.
             {provider, ergw_aaa_radius, [
                 {nas_identifier, <<"nas_id1">>},
                 {radius_auth_server, {{127,0,0,1}, 1812, <<"secret">>}},
-                {radius_acct_server, {{127,0,0,1}, 1813, <<"secret">>}}
+                {radius_acct_server, {{127,0,0,1}, 1813, <<"secret">>}},
+                {acct_interim_interval, 300},  %% Interim Accounting in seconds. By default it is 10 minutes.
+                {service_type, 'Framed-User'},
+                {framed_protocol, 'PPP'}
             ]}
         },
         {application1,

--- a/src/ergw_aaa_diameter.erl
+++ b/src/ergw_aaa_diameter.erl
@@ -47,8 +47,7 @@
 -define(DefaultOptions, [{nas_identifier, undefined},
                          {host, undefined},
                          {realm, undefined},
-                         {connect_to, undefined},
-                         {'Interim-Accounting', undefined}
+                         {connect_to, undefined}
                         ]).
 
 %%===================================================================
@@ -235,7 +234,11 @@ validate_option(host = Opt, Value) when is_binary(Value) ->
     end;
 validate_option(realm, Value) when is_binary(Value) ->
     Value;
-validate_option('Interim-Accounting', Value) when is_integer(Value) ->
+validate_option(acct_interim_interval, Value) when is_integer(Value) ->
+    Value;
+validate_option(service_type, Value) when is_atom(Value) ->
+    Value;
+validate_option(framed_protocol, Value) when is_atom(Value) ->
     Value;
 validate_option(Opt, Value) ->
     validate_option_error(Opt, Value).

--- a/src/ergw_aaa_radius.erl
+++ b/src/ergw_aaa_radius.erl
@@ -39,8 +39,7 @@
 
 -define(DefaultOptions, [{nas_identifier, undefined},
 			 {radius_auth_server, undefined},
-			 {radius_acct_server, undefined},
-			 {'Interim-Accounting', undefined}
+			 {radius_acct_server, undefined}
 			]).
 
 %%===================================================================
@@ -229,7 +228,11 @@ validate_option(Opt = disabled, Value) when is_list(Value) ->
         lists:member(El, [acct, auth])
     end, Value) orelse throw({error, {options, {Opt, Value}}}),
     lists:usort(Value);
-validate_option('Interim-Accounting', Value) when is_integer(Value) ->
+validate_option(acct_interim_interval, Value) when is_integer(Value) ->
+    Value;
+validate_option(service_type, Value) when is_atom(Value) ->
+    Value;
+validate_option(framed_protocol, Value) when is_atom(Value) ->
     Value;
 validate_option(Opt, Value) ->
     throw({error, {options, {Opt, Value}}}).

--- a/src/ergw_aaa_session.erl
+++ b/src/ergw_aaa_session.erl
@@ -92,9 +92,9 @@ init([Owner, SessionOpts]) ->
     DefaultSessionOpts = #{
       'Session-Id'         => SessionId,
       'Multi-Session-Id'   => SessionId,
-      'Service-Type'       => get_session_opt(AcctAppId, 'Service-Type', ?DEFAULT_SERVICE_TYPE),
-      'Framed-Protocol'    => get_session_opt(AcctAppId, 'Framed-Protocol', ?DEFAULT_FRAMED_PROTO),
-      'Interim-Accounting' => get_session_opt(AcctAppId, 'Interim-Accounting', ?DEFAULT_INTERIM_ACCT) * 1000
+      'Service-Type'       => get_session_opt(AcctAppId, service_type, ?DEFAULT_SERVICE_TYPE),
+      'Framed-Protocol'    => get_session_opt(AcctAppId, framed_protocol, ?DEFAULT_FRAMED_PROTO),
+      'Interim-Accounting' => get_session_opt(AcctAppId, acct_interim_interval, ?DEFAULT_INTERIM_ACCT) * 1000
      },
     Session = maps:merge(DefaultSessionOpts, SessionOpts),
     State = #state{

--- a/test/config_SUITE.erl
+++ b/test/config_SUITE.erl
@@ -25,7 +25,9 @@
 	[{nas_identifier,<<"NAS-Identifier">>},
 	 {radius_auth_server,{{127,0,0,1},1812,<<"secret">>}},
 	 {radius_acct_server,{{0,0,0,0,0,0,0,1},1813,<<"secret">>}},
-	 {'Interim-Accounting', 600}]).
+	 {acct_interim_interval, 600},
+	 {framed_protocol, 'PPP'},
+	 {service_type, 'Framed-User'}]).
 
 -define(RADIUS_CFG(Key, Value),
 	lists:keystore(Key, 1, ?RADIUS_OK_CFG, {Key, Value})).
@@ -35,7 +37,9 @@
 	 {host, <<"127.0.0.1">>},
 	 {realm, <<"example.com">>},
 	 {connect_to, <<"aaa://127.0.0.1:3868">>},
-	 {'Interim-Accounting', 600}]).
+	 {acct_interim_interval, 600},
+	 {framed_protocol, 'PPP'},
+	 {service_type, 'Framed-User'}]).
 
 -define(DIAMETER_CFG(Key, Value),
 	lists:keystore(Key, 1, ?DIAMETER_OK_CFG, {Key, Value})).
@@ -74,12 +78,18 @@ config(_Config)  ->
     ?error_option(?def_app({provider, ergw_aaa_radius, ?RADIUS_CFG(radius_acct_server, {{127,0,0,1},invalid_port,<<"secret">>})})),
     ?error_option(?def_app({provider, ergw_aaa_radius, ?RADIUS_CFG(radius_acct_server, {{127,0,0,1},1812,invalid_secret})})),
     ?error_option(?def_app({provider, ergw_aaa_radius, ?RADIUS_CFG(disabled, [invalid])})),
+    ?error_option(?def_app({provider, ergw_aaa_radius, ?RADIUS_CFG(acct_interim_interval, "10")})),
+    ?error_option(?def_app({provider, ergw_aaa_radius, ?RADIUS_CFG(service_type, "Framed-User")})),
+    ?error_option(?def_app({provider, ergw_aaa_radius, ?RADIUS_CFG(framed_protocol, "PPP")})),
 
     ?ok_option(?def_app({provider, ergw_aaa_radius, ?RADIUS_OK_CFG})),
     ?ok_option(?def_app({provider, ergw_aaa_radius, ?RADIUS_CFG(radius_acct_server, {"localhost",1812,<<"secret">>})})),
     ?ok_option(?def_app({provider, ergw_aaa_radius, ?RADIUS_CFG(disabled, [acct, auth])})),
     ?ok_option(?def_app({provider, ergw_aaa_radius, ?RADIUS_CFG(disabled, [acct])})),
     ?ok_option(?def_app({provider, ergw_aaa_radius, ?RADIUS_CFG(disabled, [])})),
+    ?ok_option(?def_app({provider, ergw_aaa_radius, ?RADIUS_CFG(acct_interim_interval, 10)})),
+    ?ok_option(?def_app({provider, ergw_aaa_radius, ?RADIUS_CFG(service_type, 'Framed-User')})),
+    ?ok_option(?def_app({provider, ergw_aaa_radius, ?RADIUS_CFG(framed_protocol, 'PPP')})),
 
 
     ?error_option(?def_app({provider, ergw_aaa_diameter, []})),
@@ -90,7 +100,9 @@ config(_Config)  ->
     ?error_option(?def_app({provider, ergw_aaa_diameter, ?DIAMETER_CFG(connect_to, invalid_uri)})),
     ?error_option(?def_app({provider, ergw_aaa_diameter, ?DIAMETER_CFG(host, <<"undefined.example.net">>)})),
     ?error_option(?def_app({provider, ergw_aaa_diameter, ?DIAMETER_CFG(connect_to, <<"http://example.com:12345">>)})),
-    ?error_option(?def_app({provider, ergw_aaa_diameter, ?DIAMETER_CFG('Interim-Accounting', <<"100">>)})),
+    ?error_option(?def_app({provider, ergw_aaa_diameter, ?DIAMETER_CFG(acct_interim_interval, <<"100">>)})),
+    ?error_option(?def_app({provider, ergw_aaa_diameter, ?DIAMETER_CFG(service_type, <<"Framed-User">>)})),
+    ?error_option(?def_app({provider, ergw_aaa_diameter, ?DIAMETER_CFG(framed_protocol, <<"PPP">>)})),
 
     ?ok_option(?def_app({provider, ergw_aaa_diameter, ?DIAMETER_OK_CFG})),
 

--- a/test/diameter_SUITE.erl
+++ b/test/diameter_SUITE.erl
@@ -33,7 +33,8 @@ init_per_suite(Config) ->
                     {host, <<"127.0.0.1">>},
                     {realm, <<"example.com">>},
                     {connect_to, <<"aaa://127.0.0.1:3868">>},
-                    {'Interim-Accounting', 1}
+                    {acct_interim_interval, 1},
+                    {service_type, 'Framed-User'}
                    ],
     Opts = [ {default, {provider, ergw_aaa_diameter, DiameterOpts} } ],
     application:load(ergw_aaa),
@@ -92,6 +93,8 @@ acct_interim_interval(_Config) ->
     timer:sleep(100),
     {state, _, _, _, _, _, _, _, SessionMap} = sys:get_state(Session),
     1000 = maps:get('Interim-Accounting', SessionMap),
+    'Framed-User' = maps:get('Service-Type', SessionMap),
+    'PPP' = maps:get('Framed-Protocol', SessionMap),
 
     % In ACA we have Acct-Interim-Interval = 100
     % that means for 2 seconds at least 2 ACR Interim reqs will be sent.

--- a/test/diameter_test_server.erl
+++ b/test/diameter_test_server.erl
@@ -81,7 +81,7 @@ handle_request(#diameter_packet{msg = Msg}, _SvcName, {_, Caps})
     {ok, Apps} = application:get_env(ergw_aaa, applications),
     InterimAccounting = case lists:keyfind(default, 1, Apps) of
                             {default, {_, _, Opts}} ->
-                                case lists:keyfind('Interim-Accounting', 1, Opts) of
+                                case lists:keyfind(acct_interim_interval, 1, Opts) of
                                     false ->
                                         1;
                                     {_, Interim} ->


### PR DESCRIPTION
as it will continue to be validate if passed, but ergw_aaa not
crashed without it.

Default value didn't changed from https://github.com/travelping/ergw_aaa/commit/ea3c0c421c7c72e688b613d6fe397b7110532384 and still to be 10mins if it is not passed.

Additionally option was renamed to `interim_accounting` for consistency.