### PR TITLE
Fix applying configured `acct_interim_interval`

### DIFF
--- a/src/ergw_aaa_profile.erl
+++ b/src/ergw_aaa_profile.erl
@@ -7,7 +7,7 @@
 
 -module(ergw_aaa_profile).
 
--export([initialize_provider/1, action/2, action/3, handle_reply/3]).
+-export([initialize_provider/1, action/2, action/3, handle_reply/3, get_application_opts/1]).
 
 -compile({parse_transform, cut}).
 

--- a/src/ergw_aaa_session.erl
+++ b/src/ergw_aaa_session.erl
@@ -88,13 +88,14 @@ init([Owner, SessionOpts]) ->
     AcctAppId = maps:get('AAA-Application-Id', SessionOpts, default),
     SessionId = ergw_aaa_session_seq:inc(AcctAppId),
     MonRef = erlang:monitor(process, Owner),
+    {ok, {_App, AppOpts, _AppAttrMap}} = ergw_aaa_profile:get_application_opts(AcctAppId),
 
     DefaultSessionOpts = #{
       'Session-Id'         => SessionId,
       'Multi-Session-Id'   => SessionId,
-      'Service-Type'       => get_session_opt(AcctAppId, service_type, ?DEFAULT_SERVICE_TYPE),
-      'Framed-Protocol'    => get_session_opt(AcctAppId, framed_protocol, ?DEFAULT_FRAMED_PROTO),
-      'Interim-Accounting' => get_session_opt(AcctAppId, acct_interim_interval, ?DEFAULT_INTERIM_ACCT) * 1000
+      'Service-Type'       => proplists:get_value(service_type, AppOpts, ?DEFAULT_SERVICE_TYPE),
+      'Framed-Protocol'    => proplists:get_value(framed_protocol, AppOpts, ?DEFAULT_FRAMED_PROTO),
+      'Interim-Accounting' => proplists:get_value(acct_interim_interval, AppOpts, ?DEFAULT_INTERIM_ACCT) * 1000
      },
     Session = maps:merge(DefaultSessionOpts, SessionOpts),
     State = #state{
@@ -335,10 +336,3 @@ handle_owner_exit(State)
 handle_owner_exit(_State) ->
     ok.
 
-get_session_opt(AcctAppId, Opt, Default) ->
-    case application:get_env(AcctAppId, Opt) of
-        undefined ->
-            Default;
-        {ok, Val} ->
-            Val
-    end.


### PR DESCRIPTION
ea3c0c4 introduced a first version of reading the a configured value for
the `Interim-Accounting` interval. Unnoticed that code did not work
because the actual configuration structure is nested like:

    {applications,[
      {default,{provider,ergw_aaa_radius,
        [{nas_identifier,<<"capwap-ac">>},
          {radius_auth_server,{{127,0,0,1},1812,<<"empty">>}},
          {radius_acct_server,{{127,0,0,1},1813,<<"empty">>}},
          {acct_interim_interval, 10}
        ]}
    }

This commit fixes the issue by using ergw_aaa_profile:get_application_opts/1
which retrieves the application options.