### PR TITLE
set authenticated to false after accounting stop

### DIFF
--- a/src/ergw_aaa_session.erl
+++ b/src/ergw_aaa_session.erl
@@ -162,7 +162,7 @@ handle_cast({stop, SessionOpts}, State) ->
     State0 = stop_interim_accounting(State),
     NewSessionOpts = maps:merge(State#state.session, SessionOpts),
     {_, NewSession} = ?action('Account', 'Stop', NewSessionOpts),
-    {noreply, State0#state{session = NewSession, started = false}};
+    {noreply, State0#state{session = NewSession, started = false, authenticated = false}};
 
 handle_cast(terminate, State) ->
     lager:info("Handling terminate request: ~p", [State]),


### PR DESCRIPTION
in other way we may get timeout error if we send another Auth without
stopping of session process