### PR TITLE
Add configurable transport options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ erGW-AAA - AAA component for the [erGW project][1]
 [![Coverage Status][coveralls badge]][coveralls]
 [![Erlang Versions][erlang version badge]][travis]
 
-This is a companion project for the [erGW project][1] to provide an abstract AAA (Authentication, Authorization and Accounting) interface for protocols based on erGW.
+This is a companion project for the [erGW project][1] to provide an abstract
+AAA (Authentication, Authorization and Accounting) interface for protocols
+based on erGW.
 
 Supported backend providers are:
 
@@ -31,18 +33,22 @@ Using rebar3:
 CONFIGURATION
 -------------
 
-For all releases in the 3.x stream, the configuration syntax might change at any point and might not be backward compatible.
+For all releases in the 3.x stream, the configuration syntax might change at
+any point and might not be backward compatible.
 
 Example of possible config.
 
 ```erlang
  {ergw_aaa,
-  [{transports,
+  [{functions,
     [{'ergw-pgw-epc',
       [{handler, ergw_aaa_diameter},
-       {host, <<"ergw-pgw.dia.example.net">>},
-       {realm, <<"dia.example.net">>},
-       {connect_to, <<"aaa://srv1.dia.example.net;transport=sctp">>}
+       {'Origin-Host', <<"ergw-pgw.dia.example.net">>},
+       {'Origin-Realm', <<"dia.example.net">>},
+       {transports, [
+           [{connect_to, <<"aaa://srv1.dia.example.net;transport=sctp">>},
+            {recbuf, 32768}]
+        ]},
       ]}
     ]},
    {handlers,

--- a/test/config_SUITE.erl
+++ b/test/config_SUITE.erl
@@ -229,6 +229,18 @@ config(_Config)  ->
     ?error_set([functions, 'diam-test', transports, 1, connect_to], invalid_uri),
     ?error_set([functions, 'diam-test', transports, 1, connect_to], <<"http://example.com:12345">>),
 
+    % transport options
+    ?ok_set([functions, 'diam-test', transports, 1, recbuf], 424242),
+    ?ok_set([functions, 'diam-test', transports, 1, sndbuf], 424242),
+    ?ok_set([functions, 'diam-test', transports, 1, unordered], false),
+    ?ok_set([functions, 'diam-test', transports, 1, reuseaddr], false),
+    ?error_set([functions, 'diam-test', transports, 1, recbuf], invalid),
+    ?error_set([functions, 'diam-test', transports, 1, recbuf], 13),
+    ?error_set([functions, 'diam-test', transports, 1, sndbuf], invalid),
+    ?error_set([functions, 'diam-test', transports, 1, sndbuf], 13),
+    ?error_set([functions, 'diam-test', transports, 1, unordered], invalid),
+    ?error_set([functions, 'diam-test', transports, 1, reuseaddr], invalid),
+
     ?error_set([handlers, ergw_aaa_nasreq], []),
     ?error_set([handlers, ergw_aaa_nasreq, invalid_option], []),
 


### PR DESCRIPTION
This commit adds configurable transport options for both TCP and SCTP:

* reuseaddr: (default: true)
* unordered: (default: true)
* recbuf - if configured, the value must be larger than 16k
* sndbuf - if configured, the value must be larger than 16k

A configuration with these settings looks like:

    [{handler, ergw_aaa_diameter},
     {'Origin-Host', <<"ergw-pgw.dia.example.net">>},
     {'Origin-Realm', <<"dia.example.net">>},
     {transports, [[{connect_to, <<"aaa://srv1.dia.example.net;transport=sctp">>},
                    {recbuf, 32768},
                    {sndbuf, 32768}]]}]