### PR TITLE
Add nodelay to tcp transport opt filter

### DIFF
--- a/src/ergw_aaa_diameter.erl
+++ b/src/ergw_aaa_diameter.erl
@@ -165,7 +165,7 @@ transport_module(_) -> unknown.
 
 transport_config(tcp, Type, Raddr, Port, Opts) ->
     [Type, {raddr, Raddr}, {rport, Port}
-     | maps:to_list(maps:with([reuseaddr, recbuf, sndbuf], Opts))];
+     | maps:to_list(maps:with([reuseaddr, recbuf, sndbuf, nodelay], Opts))];
 transport_config(sctp, Type, Raddr, Port, Opts) ->
     [Type, {raddr, Raddr}, {rport, Port}
      | maps:to_list(maps:with([reuseaddr, recbuf, sndbuf, unordered], Opts))].


### PR DESCRIPTION
Unfortunately missed this in the initial implementation for adding this option