### PR TITLE
Optionally send Framed-Pool in AAR

### DIFF
--- a/dia/diameter_3gpp_ts29_061_sgi.dia
+++ b/dia/diameter_3gpp_ts29_061_sgi.dia
@@ -65,6 +65,8 @@
               [ Framed-IP-Netmask ]
               [ Framed-MTU ]
               [ Framed-Protocol ]
+              [ Framed-Pool ]
+              [ Framed-IPv6-Pool ]
               [ ARAP-Password ]
               [ ARAP-Security ]
             * [ ARAP-Security-Data ]

--- a/test/config_SUITE.erl
+++ b/test/config_SUITE.erl
@@ -237,6 +237,9 @@ config(_Config)  ->
     ?error_set([handlers, ergw_aaa_nasreq, accounting], []),
     ?ok_set([handlers, ergw_aaa_nasreq, accounting], split),
     ?ok_set([handlers, ergw_aaa_nasreq, accounting], coupled),
+    ?ok_set([handlers, ergw_aaa_nasreq, send_pool_in_AAR], true),
+    ?ok_set([handlers, ergw_aaa_nasreq, send_pool_in_AAR], false),
+    ?error_set([handlers, ergw_aaa_nasreq, send_pool_in_AAR], undefined),
 
     ?error_set([services, 'DIAMETER-Service', handler], invalid_handler),
 


### PR DESCRIPTION
Should work together with the corresponding ergw changes that add the pools to the session before authorization.