### PR TITLE
disable OTP Diameter built-in re-transmit handling

### DIFF
--- a/src/ergw_aaa_gx.erl
+++ b/src/ergw_aaa_gx.erl
@@ -198,8 +198,8 @@ prepare_request(Pkt0, SvcName, {_PeerRef, _} = Peer, CallOpts) ->
     ergw_aaa_diameter_srv:start_request(Pkt, SvcName, Peer).
 
 %% prepare_retransmit/4
-prepare_retransmit(Pkt, SvcName, Peer, CallOpts) ->
-    prepare_request(Pkt, SvcName, Peer, CallOpts).
+prepare_retransmit(_Pkt, _SvcName, _Peer, _CallOpts) ->
+    false.
 
 %% handle_answer/5
 handle_answer(#diameter_packet{msg = Msg}, _Request, SvcName, Peer, _CallOpts) ->

--- a/src/ergw_aaa_nasreq.erl
+++ b/src/ergw_aaa_nasreq.erl
@@ -258,8 +258,8 @@ prepare_request(Pkt0, SvcName, {_PeerRef, _} = Peer, CallOpts) ->
     ergw_aaa_diameter_srv:start_request(Pkt, SvcName, Peer).
 
 %% prepare_retransmit/4
-prepare_retransmit(Pkt, SvcName, Peer, CallOpts) ->
-    prepare_request(Pkt, SvcName, Peer, CallOpts).
+prepare_retransmit(_Pkt, _SvcName, _Peer, _CallOpts) ->
+    false.
 
 %% handle_answer/5
 handle_answer(#diameter_packet{msg = Msg}, _Request, SvcName, Peer, _CallOpts) ->

--- a/src/ergw_aaa_rf.erl
+++ b/src/ergw_aaa_rf.erl
@@ -198,8 +198,8 @@ prepare_request(Pkt0, SvcName, {_PeerRef, _} = Peer, CallOpts) ->
     ergw_aaa_diameter_srv:start_request(Pkt, SvcName, Peer).
 
 %% prepare_retransmit/4
-prepare_retransmit(Pkt, SvcName, Peer, CallOpts) ->
-    prepare_request(Pkt, SvcName, Peer, CallOpts).
+prepare_retransmit(_Pkt, _SvcName, _Peer, _CallOpts) ->
+    false.
 
 %% handle_answer/5
 handle_answer(#diameter_packet{msg = Msg}, _Request, SvcName, Peer, _CallOpts) ->

--- a/src/ergw_aaa_ro.erl
+++ b/src/ergw_aaa_ro.erl
@@ -209,8 +209,8 @@ prepare_request(Pkt0, SvcName, {_PeerRef, _} = Peer, CallOpts) ->
     ergw_aaa_diameter_srv:start_request(Pkt, SvcName, Peer).
 
 %% prepare_retransmit/4
-prepare_retransmit(Pkt, SvcName, Peer, CallOpts) ->
-    prepare_request(Pkt, SvcName, Peer, CallOpts).
+prepare_retransmit(_Pkt, _SvcName, _Peer, _CallOpts) ->
+    false.
 
 %% handle_answer/5
 handle_answer(#diameter_packet{msg = [_ | #{'Result-Code' := Code}]},
@@ -231,11 +231,14 @@ handle_error(Reason, _Request, SvcName, Peer, CallOpts) ->
     ok = ergw_aaa_diameter_srv:finish_request(SvcName, Peer),
     maybe_retry(Reason, SvcName, Peer, CallOpts).
 
-maybe_retry(Reason, SvcName, Peer,
-	    #diam_call{opts = #{'CC-Session-Failover' := supported}} = CallOpts) ->
-    ergw_aaa_diameter_srv:retry_request(Reason, SvcName, Peer, CallOpts);
-maybe_retry(Reason, _SvcName, _Peer, _CallOpts) ->
-    {error, Reason}.
+maybe_retry(Reason, SvcName, Peer, CallOpts) ->
+    ergw_aaa_diameter_srv:retry_request(Reason, SvcName, Peer, CallOpts).
+
+%% maybe_retry(Reason, SvcName, Peer,
+%% 	    #diam_call{opts = #{'CC-Session-Failover' := supported}} = CallOpts) ->
+%%     ergw_aaa_diameter_srv:retry_request(Reason, SvcName, Peer, CallOpts);
+%% maybe_retry(Reason, _SvcName, _Peer, _CallOpts) ->
+%%     {error, Reason}.
 
 handle_request(#diameter_packet{msg = [Command | Avps]}, _SvcName, Peer)
   when Command =:= 'ASR'; Command =:= 'RAR' ->


### PR DESCRIPTION
The OTP Diameter stack tries to re-transmit a request to another
peer if the FSM for the original host transitions from UP to
something else (SUSPECT or DOWN). None the callbacks (peer_down/2,
handle_error or handle_result) are called when that happens.

This cause the request tracking in the load estimation logic to
go out of sync, ultimately breaking load distribution completely.

This change disables the built-in re-transmission all together and
let the application handle it.

Gy host stickiness and fail-over support is still incorrect (as it
was before).