### PR TITLE
fix outstanding request tracking for broken answers

### DIFF
--- a/src/ergw_aaa_diameter.erl
+++ b/src/ergw_aaa_diameter.erl
@@ -16,6 +16,7 @@
 -export([encode_ipv6prefix/1, decode_ipv6prefix/1]).
 
 -include_lib("kernel/include/inet.hrl").
+-include_lib("kernel/include/logger.hrl").
 -include_lib("diameter/include/diameter.hrl").
 -include_lib("diameter/include/diameter_gen_base_rfc6733.hrl").
 -include("include/diameter_3gpp_ts29_061_sgi.hrl").

--- a/src/ergw_aaa_rf.erl
+++ b/src/ergw_aaa_rf.erl
@@ -81,6 +81,7 @@ initialize_service(_ServiceId, #{function := Function}) ->
 		  'Vendor-Id'           = ?VENDOR_ID_3GPP,
 		  'Acct-Application-Id' = [?DIAMETER_APP_ID_RF]}],
 	  application => [{alias, ?APP},
+			  {answer_errors, callback},
 			  {dictionary, ?DIAMETER_DICT_RF},
 			  {module, ?MODULE}]},
     ergw_aaa_diameter_srv:register_service(Function, SvcOpts),
@@ -212,6 +213,16 @@ prepare_retransmit(_Pkt, _SvcName, _Peer, _CallOpts) ->
     false.
 
 %% handle_answer/5
+handle_answer(#diameter_packet{msg = Msg, errors = Errors},
+	      _Request, SvcName, Peer, _CallOpts)
+  when length(Errors) /= 0 ->
+    ?LOG(error, "~p: decode of answer from ~p failed, errors ~p", [SvcName, Peer, Errors]),
+    ok = ergw_aaa_diameter_srv:finish_request(SvcName, Peer),
+    case Msg of
+	[_ | #{'Result-Code' := RC}] -> {error, RC};	%% try to handle gracefully
+	_                            -> {error, failed}
+    end;
+
 handle_answer(#diameter_packet{msg = Msg}, _Request, SvcName, Peer, _CallOpts) ->
     ok = ergw_aaa_diameter_srv:finish_request(SvcName, Peer),
     Msg.

--- a/test/config_SUITE.erl
+++ b/test/config_SUITE.erl
@@ -12,9 +12,6 @@
 -include_lib("common_test/include/ct.hrl").
 -include("ergw_aaa_test_lib.hrl").
 
--import(ergw_aaa_test_lib,
-	[set_cfg_value/3, get_cfg_value/2]).
-
 -define(error_option(Config),
 	?match({error,{_, _}}, (catch ergw_aaa_config:validate_config(Config)))).
 	%% ?match({error,{options, _}}, (catch ergw_aaa_config:validate_config(Config)))).

--- a/test/ergw_aaa_test_lib.erl
+++ b/test/ergw_aaa_test_lib.erl
@@ -1,4 +1,4 @@
-%% Copyright 2017,2018, Travelping GmbH <info@travelping.com>
+%% Copyright 2017-2020, Travelping GmbH <info@travelping.com>
 
 %% This program is free software; you can redistribute it and/or
 %% modify it under the terms of the GNU General Public License
@@ -7,9 +7,12 @@
 
 -module(ergw_aaa_test_lib).
 
+-define(ERGW_AAA_NO_IMPORTS, true).
+
 -export([meck_init/1, meck_reset/1, meck_unload/1, meck_validate/1]).
 -export([set_cfg_value/3, get_cfg_value/2]).
 -export([get_stats/1, diff_stats/2, wait_for_diameter/2]).
+-export([outstanding_reqs/0]).
 
 -include("ergw_aaa_test_lib.hrl").
 
@@ -153,3 +156,7 @@ diff_stats(S1, S2) ->
 		  end
 	  end, S2, S1),
     Stats ++ Rest.
+
+outstanding_reqs() ->
+    lists:foldl(
+      fun({_, O, _, _, _, _, _}, S) -> S + O end, 0, ergw_aaa_diameter_srv:peers()).

--- a/test/ergw_aaa_test_lib.hrl
+++ b/test/ergw_aaa_test_lib.hrl
@@ -22,3 +22,10 @@
 			   error(badmatch)
 		  end
 	  end)())).
+
+-ifndef(ERGW_AAA_NO_IMPORTS).
+-import(ergw_aaa_test_lib, [meck_init/1, meck_reset/1, meck_unload/1, meck_validate/1,
+			    set_cfg_value/3, get_cfg_value/2,
+			    get_stats/1, diff_stats/2, wait_for_diameter/2,
+			    outstanding_reqs/0]).
+-endif.

--- a/test/radius_SUITE.erl
+++ b/test/radius_SUITE.erl
@@ -15,10 +15,6 @@
 -include_lib("diameter/include/diameter_gen_base_rfc6733.hrl").
 -include("ergw_aaa_test_lib.hrl").
 
--import(ergw_aaa_test_lib, [meck_init/1, meck_reset/1, meck_unload/1, meck_validate/1,
-			    set_cfg_value/3,
-			    get_stats/1, diff_stats/2, wait_for_diameter/2]).
-
 -define(HUT, ergw_aaa_radius).
 -define(SERVICE, 'aaa-test').
 

--- a/test/static_SUITE.erl
+++ b/test/static_SUITE.erl
@@ -17,9 +17,6 @@
 -include("../include/ergw_aaa_session.hrl").
 -include("ergw_aaa_test_lib.hrl").
 
--import(ergw_aaa_test_lib, [meck_init/1, meck_reset/1, meck_unload/1, meck_validate/1,
-			    get_stats/1, diff_stats/2, wait_for_diameter/2]).
-
 -define(HUT, ergw_aaa_static).
 
 -define(STATIC_CONFIG,


### PR DESCRIPTION
Broken answers can bybass the request tracking, leading to wrong
load statistics. Make sure we capture them.
Add explicit test cases and enhance the existing case.