### PR TITLE
Use accounting trigger for nasreq accounting

### DIFF
--- a/src/ergw_aaa_nasreq.erl
+++ b/src/ergw_aaa_nasreq.erl
@@ -364,7 +364,7 @@ to_session(Procedure, {Session0, Events0}, Avps) ->
 %% to_session/4
 to_session(_, 'Acct-Interim-Interval', [Interim], {Session, Events})
   when is_integer(Interim), Interim > 0 ->
-    Trigger = ergw_aaa_session:trigger(?MODULE, 'IP-CAN', periodic, Interim),
+    Trigger = ergw_aaa_session:trigger(accounting, 'IP-CAN', periodic, Interim),
     {Session#{'Acct-Interim-Interval' => Interim}, ergw_aaa_session:ev_set(Trigger, Events)};
 
 to_session(_, 'Framed-IP-Address', [<<A,B,C,D>>], {Session, Events}) ->

--- a/test/diameter_nasreq_SUITE.erl
+++ b/test/diameter_nasreq_SUITE.erl
@@ -169,7 +169,7 @@ simple(Config) ->
 			'Framed-IPv6-Pool' => <<"pool-A">>}),
 
     {ok, _, Events} = ergw_aaa_session:invoke(Session, #{}, authenticate, []),
-    ?match([{set, {{ergw_aaa_nasreq, 'IP-CAN', periodic}, {periodic, 'IP-CAN', 1800, []}}}],
+    ?match([{set, {{accounting, 'IP-CAN', periodic}, {periodic, 'IP-CAN', 1800, []}}}],
 	   Events),
     ?match({ok, _, _}, ergw_aaa_session:invoke(Session, #{}, authorize, [])),
     ?match({ok, _, _}, ergw_aaa_session:invoke(Session, #{}, start, [])),
@@ -230,7 +230,7 @@ acct_interim_interval(Config) ->
 	     'Service-Type' := 'Framed-User',
 	     'Framed-Protocol' := 'PPP'
 	    }, SessionOpts),
-    ?match([{set, {{ergw_aaa_nasreq, 'IP-CAN', periodic},
+    ?match([{set, {{accounting, 'IP-CAN', periodic},
 		   {periodic, 'IP-CAN', 1, _}}}], Ev),
 
     %% make sure nothing crashed


### PR DESCRIPTION
Using the same accounting trigger as radius fixes the missing volume
report AVPs : Accounting-Input-Octets and Accounting-Output-Octets
in interim and stop NASREQ ACR.

The minor limitation of this solution is that both NASREQ and RADIUS
accounting with different interim report intervals can not be used the
same time in a deployment. It is a very unlikely case though.