### PR TITLE
Add QoS-Information to RO default AVP filter

### DIFF
--- a/src/ergw_aaa_ro.erl
+++ b/src/ergw_aaa_ro.erl
@@ -56,7 +56,7 @@
 			 {'Credit-Control-Failure-Handling', terminate},
 			 {answer_if_down, reject},
 			 {answer_if_timeout, reject},
-			 {avp_filter, [['3GPP-IMSI']]}]).
+			 {avp_filter, [['3GPP-IMSI'], ['Service-Information', 'PS-Information', 'QoS-Information']]}]).
 
 -define(IS_IP(X), (is_tuple(X) andalso (tuple_size(X) == 4 orelse tuple_size(X) == 8))).
 

--- a/test/diameter_avp_filter_SUITE.erl
+++ b/test/diameter_avp_filter_SUITE.erl
@@ -141,15 +141,22 @@ end_per_testcase(Config) ->
 %%%===================================================================
 
 %%====================================================================
-%% Default filter (for ro it is ['3GPP-IMSI'])
-%% override default filter with empty list and check if before we have
-%% '3GPP-IMSI' filtered out by the default filter, then present after
-%% empty filter is applied
+%% Default filter (for ro it is [['3GPP-IMSI'], ['Service-Information',
+%% 'PS-Information', 'QoS-Information']]), override default filter with 
+%% empty list and check if before we have '3GPP-IMSI' and 'QoS-Information'
+%% filtered out by the default filter, then present after empty filter 
+%% is applied
 %%====================================================================
 default_filter(_Config) ->
     {Before, After} = do_filter_test([]),
+    
     ?equal(undefined, maps:get('3GPP-IMSI', Before, undefined)),
+    #{'Service-Information' := [#{'PS-Information' := [PSInfoBefore]}]} = Before,
+    ?equal(undefined, maps:get('QoS-Information', PSInfoBefore, undefined)),
+
     ?match([_], maps:get('3GPP-IMSI', After)),
+    ?match(#{'Service-Information' := [#{'PS-Information' := [#{'QoS-Information' := _ }]}]}, After),
+
     ok.
 
 %%====================================================================


### PR DESCRIPTION
The QoS-information AVP on the RO/Gy interface wasn't sent previously. To make sure that this AVP does not impact existing deployments without having to add specific filter config, it should to be added to the default filter.