### PR TITLE
Pass as 64bit binary, and not as full IPv6 address

### DIFF
--- a/src/ergw_aaa_radius.erl
+++ b/src/ergw_aaa_radius.erl
@@ -398,8 +398,8 @@ session_options('Framed-IPv6-Prefix', Value, Attrs) ->
     [{?Framed_IPv6_Prefix, Value}|Attrs];
 session_options('Framed-IPv6-Pool', Value, Attrs) ->
     [{?Framed_IPv6_Pool, Value}|Attrs];
-session_options('Framed-Interface-Id', Value, Attrs) ->
-    [{?Framed_Interface_Id, Value}|Attrs];
+session_options('Framed-Interface-Id', {_,_,_,_,E,F,G,H}, Attrs) ->
+    [{?Framed_Interface_Id, <<E:16,F:16,G:16,H:16>>}|Attrs];
 
 session_options('Session-Id', Value, Attrs) ->
     Id = io_lib:format("~40.16.0B", [Value]),

--- a/test/radius_SUITE.erl
+++ b/test/radius_SUITE.erl
@@ -351,7 +351,8 @@ simple(Config, Opts) ->
 		      #{'Framed-IP-Address' => {10,10,10,10},
 			'Framed-IPv6-Prefix' => {{16#fe80,0,0,0,0,0,0,0}, 64},
 			'Framed-Pool' => <<"pool-A">>,
-			'Framed-IPv6-Pool' => <<"pool-A">>}),
+			'Framed-IPv6-Pool' => <<"pool-A">>,
+			'Framed-Interface-Id' => {0,0,0,0,0,0,0,1}}),
 
     {ok, _, Events} = ergw_aaa_session:invoke(Session, #{}, authenticate, []),
 


### PR DESCRIPTION
Fix error:
```sh
2020-10-23T11:18:30.875322+00:00 <0.1438.0> error: crasher: initial call: ergw_aaa_radius:'-accounting/6-fun-0-'/0, pid: <0.1438.0>, registered_name: [], error: {function_clause,[{eradius_lib,encode_value,[octets,{0,0,0,0,0,0,0,1}],[{file,"/build/_build/default/lib/eradius/src/eradius_lib.erl"},{line,191}]},{eradius_lib,encode_attribute,3,[{file,"/build/_build/default/lib/eradius/src/eradius_lib.erl"},{line,177}]},{eradius_lib,'-encode_attributes/2-fun-0-',3,[{file,"/build/_build/default/lib/eradius/src/eradius_lib.erl"},{line,143}]},{lists,foldl,3,[{file,"lists.erl"},{line,1267}]},{eradius_lib,encode_request,1,[{file,"/build/_build/default/lib/eradius/src/eradius_lib.erl"},{line,73}]},{eradius_client,send_request_loop,7,[{file,"/build/_build/default/lib/eradius/src/eradius_client.erl"},{line,172}]},{eradius_client,send_request,3,[{file,"/build/_build/default/lib/eradius/src/eradius_client.erl"},{line,87}]},{proc_lib,init_p,3,[{file,"proc_lib.erl"},{line,211}]}]}, ancestors: [<0.1428.0>,ergw_aaa_session_sup,ergw_aaa_sup,<0.922.0>], message_queue_len: 0, messages: [], links: [], dictionary: [], trap_exit: false, status: running, heap_size: 2586, stack_size: 28, reductions: 841; neighbours:
```