### PR TITLE
fix vendor dicts validation

### DIFF
--- a/src/ergw_aaa_radius.erl
+++ b/src/ergw_aaa_radius.erl
@@ -217,14 +217,8 @@ validate_avp_filters({vendor, Vendor} = Attr, M)
 validate_avp_filters(Value, _) ->
     throw({error, {options, {avp_filter, Value}}}).
 
-validate_vendor(Vendor)
-  when is_integer(Vendor), Vendor > 0, Vendor =< 16#ffffffff ->
-    case eradius_dict:lookup(vendor, Vendor) of
-	false ->
-	    throw({error, {options, {vendor_dicts, Vendor}}});
-	_ ->
-	    Vendor
-    end;
+validate_vendor(?'Ituma' = Vendor) -> Vendor;
+validate_vendor(ituma) -> ?'Ituma';
 validate_vendor(Vendor) ->
     throw({error, {options, {vendor_dicts, Vendor}}}).
 

--- a/test/config_SUITE.erl
+++ b/test/config_SUITE.erl
@@ -212,6 +212,14 @@ config(_Config)  ->
     ?ok_set([handlers, ergw_aaa_radius, retries], 1),
     ?ok_set([handlers, ergw_aaa_radius, timeout], 1000),
 
+    ?ok_set([handlers, ergw_aaa_radius, vendor_dicts], []),
+    ?ok_set([handlers, ergw_aaa_radius, vendor_dicts], [ituma]),
+    ?ok_set([handlers, ergw_aaa_radius, vendor_dicts], [52315]),
+    ?error_set([handlers, ergw_aaa_radius, vendor_dicts], [atom]),
+    ?error_set([handlers, ergw_aaa_radius, vendor_dicts], atom),
+    ?error_set([handlers, ergw_aaa_radius, vendor_dicts], 52315),
+    ?error_set([handlers, ergw_aaa_radius, vendor_dicts], ituma),
+
     ?error_set([services, 'RADIUS-Service', handler], invalid_handler),
 
     ?error_set([services, 'RADIUS-Test-Service'], ?RADIUS_AUTH_CONFIG),


### PR DESCRIPTION
Vendor dictionaries might no be loaded at the time the config is
validate, causing a failure of the validation function.

The special handling for vendor dictiontionaries needs to be code
in anycase, hard coding the validation instead of relying on the
load dictionieries is the sane choice.