### PR TITLE
Change ?MODULE to interface names for termination cause errors

### DIFF
--- a/src/ergw_aaa_gx.erl
+++ b/src/ergw_aaa_gx.erl
@@ -51,6 +51,7 @@
 -define(APP, 'Gx').
 -define(DIAMETER_DICT_GX, diameter_3gpp_ts29_212).
 -define(DIAMETER_APP_ID_GX, ?DIAMETER_DICT_GX:id()).
+-define(API, gx).
 
 -define(DefaultOptions, [{function, "undefined"},
 			 {'Destination-Realm', undefined},
@@ -291,22 +292,22 @@ handle_cca({error, no_connection}, Session, Events,
     handle_cca(['CCA' | Avps], Session, Events, Opts, State);
 handle_cca({error, Reason} = Result, Session, Events, _Opts, State) ->
     ?LOG(error, "CCA Result: ~p", [Result]),
-    {Result, Session, [{stop, {?MODULE, Reason}} | Events], State#state{state = stopped}}.
+    {Result, Session, [{stop, {?API, Reason}} | Events], State#state{state = stopped}}.
 
 %% handle_cca/7
 handle_cca('CCA', RC, AVPs, Session0, Events0, _Opts, State)
   when RC < 3000 ->
-    {Session, Events} = to_session({gy, 'CCA'}, {Session0, Events0}, AVPs),
+    {Session, Events} = to_session({?API, 'CCA'}, {Session0, Events0}, AVPs),
     {ok, Session, Events, State};
 handle_cca(Answer, RC, _AVPs, Session, Events, _Opts, State)
   when Answer =:= 'CCA'; Answer =:= 'answer-message' ->
-    {{fail, RC}, Session, [{stop, {?MODULE, peer_reject}} | Events], State#state{state = stopped}}.
+    {{fail, RC}, Session, [{stop, {?API, peer_reject}} | Events], State#state{state = stopped}}.
 
 handle_common_request(Command, #{'Session-Id' := SessionId} = Avps, {_PeerRef, Caps}) ->
     {Result, ReplyAvps0} =
 	case ergw_aaa_session_reg:lookup(SessionId) of
 	    Session when is_pid(Session) ->
-		ergw_aaa_session:request(Session, ?MODULE, {?MODULE, Command}, Avps);
+		ergw_aaa_session:request(Session, ?MODULE, {?API, Command}, Avps);
 	    _ ->
 		{{error, unknown_session}, #{}}
 	end,

--- a/src/ergw_aaa_nasreq.erl
+++ b/src/ergw_aaa_nasreq.erl
@@ -325,7 +325,7 @@ acct_app_alias(#{accounting := split}) -> ?BASE_ACC_APP.
 
 handle_aaa(['AAA' | #{'Result-Code' := RC} = Avps], Session0, Events0, _Opts, State)
   when RC < 3000 ->
-    {Session, Events} = to_session({nasreq, 'AAA'}, {Session0, Events0}, Avps),
+    {Session, Events} = to_session({?APP, 'AAA'}, {Session0, Events0}, Avps),
     {ok, Session, Events, State};
 handle_aaa([Answer | #{'Result-Code' := Code}], Session, Events, _Opts, State)
   when Answer =:= 'AAA'; Answer =:= 'answer-message' ->
@@ -335,11 +335,11 @@ handle_aaa({error, _} = Result, Session, Events, _Opts, State) ->
 
 handle_aca(['ACA' | #{'Result-Code' := RC} = Avps], Session0, Events0, _Opts, State)
   when RC < 3000 ->
-    {Session, Events} = to_session({nasreq, 'ACA'}, {Session0, Events0}, Avps),
+    {Session, Events} = to_session({?APP, 'ACA'}, {Session0, Events0}, Avps),
     {ok, Session, Events, State};
 handle_aca([Answer | #{'Result-Code' := RC}], Session, Events, _Opts, State)
   when Answer =:= 'ACA'; Answer =:= 'answer-message' ->
-    {{fail, RC}, Session, [{stop, {?MODULE, peer_reject}} | Events], State};
+    {{fail, RC}, Session, [{stop, {?APP, peer_reject}} | Events], State};
 handle_aca({error, _} = Result, Session, Events, _Opts, State) ->
     {Result, Session, Events, State}.
 

--- a/src/ergw_aaa_ro.erl
+++ b/src/ergw_aaa_ro.erl
@@ -49,6 +49,7 @@
 -define(APP, 'Ro').
 -define(DIAMETER_DICT_RO, diameter_3gpp_ts32_299_ro).
 -define(DIAMETER_APP_ID_RO, ?DIAMETER_DICT_RO:id()).
+-define(API, gy).
 
 -define(DefaultOptions, [{function, "undefined"},
 			 {'Destination-Realm', undefined},
@@ -319,11 +320,11 @@ validate_option_error(Opt, Value) ->
 handle_cca(['CCA' | #{'Result-Code' := Code} = Avps],
 	   Session0, Events0, _Opts, State)
   when Code < 3000 ->
-    {Session, Events} = to_session({gy, 'CCA'}, {Session0, Events0}, Avps),
+    {Session, Events} = to_session({?API, 'CCA'}, {Session0, Events0}, Avps),
     {ok, Session, Events, State};
 handle_cca([Answer | #{'Result-Code' := Code}], Session, Events, _Opts, State)
   when Answer =:= 'CCA'; Answer =:= 'answer-message' ->
-    {{fail, Code}, Session, [{stop, {?MODULE, peer_reject}} | Events], State};
+    {{fail, Code}, Session, [{stop, {?API, peer_reject}} | Events], State};
 handle_cca({error, no_connection}, Session, Events,
 	   #{answer_if_down := Answer, answers := Answers} = Opts, State0) ->
     {Avps, State} =
@@ -339,13 +340,13 @@ handle_cca({error, rate_limit}, Session, Events,
     handle_cca(['CCA' | Avps], Session, Events, Opts, State);
 handle_cca({error, Reason} = Result, Session, Events, _Opts, State) ->
     ?LOG(error, "CCA Result: ~p", [Result]),
-    {Result, Session, [{stop, {?MODULE, Reason}} | Events], State#state{state = stopped}}.
+    {Result, Session, [{stop, {?API, Reason}} | Events], State#state{state = stopped}}.
 
 handle_common_request(Command, #{'Session-Id' := SessionId} = Avps, {_PeerRef, Caps}) ->
     {Result, ReplyAvps0} =
 	case ergw_aaa_session_reg:lookup(SessionId) of
 	    Session when is_pid(Session) ->
-		ergw_aaa_session:request(Session, ?MODULE, {?MODULE, Command}, Avps);
+		ergw_aaa_session:request(Session, ?MODULE, {?API, Command}, Avps);
 	    _ ->
 		{{error, unknown_session}, #{}}
 	end,

--- a/src/ergw_aaa_static.erl
+++ b/src/ergw_aaa_static.erl
@@ -87,8 +87,10 @@ handle_response(Procedure, #{'Result-Code' := Code} = Avps,
   when Code < 3000 ->
     {Session, Events} = to_session(Procedure, {Session0, Events0}, Avps),
     {ok, Session, Events, State};
-handle_response(_Procedure, #{'Result-Code' := Code}, Session, Events, State) ->
-    {{fail, Code}, Session, [{stop, {?MODULE, peer_reject}} | Events], State};
+handle_response({API, _}, #{'Result-Code' := Code}, Session, Events, State) ->
+    {{fail, Code}, Session, [{stop, {API, peer_reject}} | Events], State};
+handle_response(Procedure, #{'Result-Code' := Code}, Session, Events, State) ->
+    {{fail, Code}, Session, [{stop, {Procedure, peer_reject}} | Events], State};
 handle_response(_Procedure, Response, Session, Events, State) ->
     ?LOG(error, "Response: ~p", [Response]),
     {Response, Session, Events, State}.

--- a/test/diameter_Gx_SUITE.erl
+++ b/test/diameter_Gx_SUITE.erl
@@ -25,6 +25,7 @@
 
 -define(HUT, ergw_aaa_gx).
 -define(SERVICE, ergw_aaa_gx).
+-define(API, gx).
 
 -define('Origin-Host', <<"127.0.0.1">>).
 -define('Origin-Realm', <<"example.com">>).
@@ -253,7 +254,7 @@ abort_session_request(Config) ->
     ?equal([{ergw_aaa_gx, started, 1}], get_session_stats()),
 
     receive
-	#aaa_request{procedure = {?HUT, 'ASR'}} = Request ->
+	#aaa_request{procedure = {?API, 'ASR'}} = Request ->
 	    ergw_aaa_session:response(Request, ok, #{}, #{})
     after 1000 ->
 	    ct:fail("no ASR")
@@ -355,7 +356,7 @@ re_auth_request(Config) ->
 						    RAROpts)),
 
     receive
-	#aaa_request{procedure = {?HUT, 'RAR'}, events = Events} = Request ->
+	#aaa_request{procedure = {?API, 'RAR'}, events = Events} = Request ->
 	    ?match([{pcc, install, [#{'Charging-Rule-Name' := [<<"service01">>]}]}],
 		   Events),
 	    ergw_aaa_session:response(Request, ok, #{}, #{})
@@ -369,7 +370,7 @@ re_auth_request(Config) ->
 						    ?'Origin-Host', ?'Origin-Realm',
 						    RAROpts)),
     receive
-	#aaa_request{procedure = {?HUT, 'RAR'}, events = Evs2} = Req2 ->
+	#aaa_request{procedure = {?API, 'RAR'}, events = Evs2} = Req2 ->
 	    ?match([{pcc, install, [#{'Charging-Rule-Name' := [<<"service01">>]}]}],
 		   Evs2),
 	    %% check that the session is not blocked for other DIAMETER Apps

--- a/test/diameter_Gy_SUITE.erl
+++ b/test/diameter_Gy_SUITE.erl
@@ -19,6 +19,7 @@
 
 -define(HUT, ergw_aaa_ro).
 -define(SERVICE, 'diam-test').
+-define(API, gy).
 -define(SET_TC_INFO(Name, Value), set_test_info(?FUNCTION_NAME, Name, Value)).
 -define(GET_TC_INFO(Name), get_test_info(?FUNCTION_NAME, Name)).
 -define(GET_TC_INFO(Name, Default), get_test_info(?FUNCTION_NAME, Name)).
@@ -394,7 +395,7 @@ abort_session_request(Config) ->
     ?equal(ok, diameter_test_server:abort_session_request(gy, SessionId, ?'Origin-Host', ?'Origin-Realm')),
 
     receive
-	#aaa_request{procedure = {?HUT, 'ASR'}} = Request ->
+	#aaa_request{procedure = {?API, 'ASR'}} = Request ->
 	    ergw_aaa_session:response(Request, ok, #{}, #{})
     after 1000 ->
 	    ct:fail("no ASR")
@@ -658,7 +659,7 @@ ocs_hold_initial_timeout(Config) ->
 		    'Reporting-Reason' => [?'DIAMETER_3GPP_CHARGING_REPORTING-REASON_VALIDITY_TIME']}
 	 },
     GyTerm = #{used_credits => maps:to_list(UsedCredits)},
-    ?match({{error, ocs_hold_end}, _Session2, [{stop, {?HUT, ocs_hold_end}}]},
+    ?match({{error, ocs_hold_end}, _Session2, [{stop, {?API, ocs_hold_end}}]},
 	   ergw_aaa_session:invoke(SId, GyTerm, {gy, 'CCR-Update'}, [])),
 
     Stats1 = diff_stats(Stats0, get_stats(?SERVICE)),
@@ -721,7 +722,7 @@ ocs_hold_update_timeout(Config) ->
 
     GyTerm = #{'Termination-Cause' => ?'DIAMETER_BASE_TERMINATION-CAUSE_LOGOUT',
 	       used_credits => UsedCredits},
-    {{error, ocs_hold_end}, _Session3, [{stop, {?HUT, ocs_hold_end}}]} = ergw_aaa_session:invoke(SId, GyTerm, {gy, 'CCR-Terminate'}, []),
+    {{error, ocs_hold_end}, _Session3, [{stop, {?API, ocs_hold_end}}]} = ergw_aaa_session:invoke(SId, GyTerm, {gy, 'CCR-Terminate'}, []),
 
     ?equal([{ergw_aaa_ro, ocs_hold, 0}, {ergw_aaa_ro, started, 0}], get_session_stats()),
 
@@ -791,7 +792,7 @@ ocs_hold_update_timeout_async(Config) ->
 
     GyTerm = #{'Termination-Cause' => ?'DIAMETER_BASE_TERMINATION-CAUSE_LOGOUT',
 	       used_credits => UsedCredits},
-    {{error, ocs_hold_end}, _Session3, [{stop, {?HUT, ocs_hold_end}}]} = ergw_aaa_session:invoke(SId, GyTerm, {gy, 'CCR-Terminate'}, []),
+    {{error, ocs_hold_end}, _Session3, [{stop, {?API, ocs_hold_end}}]} = ergw_aaa_session:invoke(SId, GyTerm, {gy, 'CCR-Terminate'}, []),
 
     ?equal([{ergw_aaa_ro, ocs_hold, 0}, {ergw_aaa_ro, started, 0}], get_session_stats()),
 

--- a/test/static_SUITE.erl
+++ b/test/static_SUITE.erl
@@ -224,7 +224,7 @@ gx_session(Config) ->
     {Result3, Session3, Events3} =
 	ergw_aaa_session:invoke(SId, GxTerm, {gx, 'CCR-Terminate'}, []),
     ?equal({fail, 5003}, Result3),
-    ?match([{stop, {?HUT, peer_reject}}], Events3),
+    ?match([{stop, {gx, peer_reject}}], Events3),
     ?equal(false, maps:is_key('Result-Code', Session3)),
 
     %% make sure nothing crashed


### PR DESCRIPTION
Based on https://github.com/travelping/ergw_aaa/pull/85 change `?MODULE` to interface names