### PR TITLE
Update eradius to 2.2.0 version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
 	{prometheus, "4.6.0"},
 	{regine, {git, "https://github.com/travelping/regine.git", {branch, "master"}}},
 	{erlando, {git, "https://github.com/travelping/erlando.git", {tag, "1.0.2"}}},
-	{eradius, {git, "https://github.com/travelping/eradius.git", {tag, "2.1.0"}}}
+	{eradius, {git, "https://github.com/travelping/eradius.git", {tag, "2.2.0"}}}
 ]}.
 
 {minimum_otp_vsn, "21.3"}.


### PR DESCRIPTION
`eradius` release notes: https://github.com/travelping/eradius/releases/tag/2.2.0