### PR TITLE
fix passing RADIUS response IEs into session

### DIFF
--- a/src/ergw_aaa_radius.erl
+++ b/src/ergw_aaa_radius.erl
@@ -293,6 +293,9 @@ to_session(_, Key, Value, {Session, Events, State})
        Key =:= 'Username';
        Key =:= 'TLS-Pre-Shared-Key' ->
    {Session, Events, maps:put(Key, Value, State)};
+to_session(_, Key, Value, {Session, Events, State})
+  when is_atom(Key) ->
+    {maps:put(Key, Value, Session), Events, State};
 to_session(_, _, _, SessEvSt) ->
     SessEvSt.
 

--- a/test/eradius_test_handler.erl
+++ b/test/eradius_test_handler.erl
@@ -50,6 +50,7 @@ radius_request(#radius_request{cmd = request, attrs = Attrs} = _Req, _Nasprop, _
 	    end;
 	_ ->
 	    IEs = [{?Acct_Interim_Interval, 1800},
+		   {?MS_Primary_DNS_Server, {8,8,8,8}},
 		   {?Filter_Id, <<"test">>}],
 	    {reply, #radius_request{cmd = accept, attrs = IEs}}
 	end;

--- a/test/radius_SUITE.erl
+++ b/test/radius_SUITE.erl
@@ -354,7 +354,8 @@ simple(Config, Opts) ->
 			'Framed-IPv6-Pool' => <<"pool-A">>,
 			'Framed-Interface-Id' => {0,0,0,0,0,0,0,1}}),
 
-    {ok, _, Events} = ergw_aaa_session:invoke(Session, #{}, authenticate, []),
+    {ok, SOut, Events} = ergw_aaa_session:invoke(Session, #{}, authenticate, []),
+    ?match(#{'MS-Primary-DNS-Server' := {8,8,8,8}}, SOut),
 
     ?equal([{ergw_aaa_radius, started, 0}], get_session_stats()),
 


### PR DESCRIPTION
RADIUS IEs are filtered during decoding. to_session/3 only needs
to split them into session options, events and state values.