### PR TITLE
Implement DIAMETER rate limiter metric collector in erGW-AAA

### DIFF
--- a/doc/METRICS.md
+++ b/doc/METRICS.md
@@ -1,7 +1,21 @@
-AAA diameter session metrics
-================================
+# erGW-AAA
+* [DIAMETER metrics](#diameter-metrics)
+* [DIAMETER session metrics](#diameter-session-metrics)
 
-ergw_aaa exposes prometheus gauge metric for the states of the different diameter handlers
+`erGW-AAA` uses [prometheus.erl](https://github.com/deadtrickster/prometheus.erl) to implement various operation metrics.
+
+# DIAMETER metrics
+
+The following metrics exist:
+| Name                                       | Type      | Labels         | Description                            |
+|--------------------------------------------|-----------|----------------|----------------------------------------|
+| aaa_sessions_total                         | gauge     | handler, state | AAA of active sessions                 |
+| ergw_aaa_diameter_outstanding_requests     | gauge     | name, type     | The number of outstanding requests     |
+| ergw_aaa_diameter_available_tokens         | gauge     | name, type     | The number of available tokens         |
+
+# DIAMETER session metrics
+
+`erGW-AAA` exposes prometheus gauge metric for the states of the different diameter handlers
  and the radius handler.
 The metrics are labeled with the name of the handler module and the handler state. The name
  of the metric is `aaa_sessions_total`.

--- a/src/ergw_aaa_internal.hrl
+++ b/src/ergw_aaa_internal.hrl
@@ -17,3 +17,12 @@
 		 }).
 
 -define(AAA_ERR(Level), #aaa_err{level=Level,where={?FILE, ?LINE}}).
+
+-record(peer, {
+    outstanding = 0,
+    capacity    = 50,
+    last_ts     = undefined,
+    rate        = 10,          %% requests per second
+    interval    = 0,           %% refill interval in microseconds
+    tokens      = 0
+}).

--- a/src/ergw_aaa_prometheus_collector.erl
+++ b/src/ergw_aaa_prometheus_collector.erl
@@ -1,0 +1,77 @@
+%% Copyright 2021, Travelping GmbH <info@travelping.com>
+
+%% This program is free software; you can redistribute it and/or
+%% modify it under the terms of the GNU General Public License
+%% as published by the Free Software Foundation; either version
+%% 2 of the License, or (at your option) any later version.
+
+-module(ergw_aaa_prometheus_collector).
+-behaviour(prometheus_collector).
+
+-include_lib("prometheus/include/prometheus.hrl").
+-include("ergw_aaa_internal.hrl").
+
+-export([
+    deregister_cleanup/1,
+    collect_mf/2,
+    collect_metrics/2,
+    gather/0
+]).
+
+-ignore_xref([gather/0, collect_metrics/2]).
+
+-import(prometheus_model_helpers, [create_mf/5, gauge_metric/2]).
+
+-define(METRIC_NAME_PREFIX, "ergw_aaa_diameter_").
+
+-define(OUTSTANDING, outstanding_requests).
+-define(TOKENS, available_tokens).
+
+-define(METRICS, [{?OUTSTANDING, gauge, "The number of outstanding requests"},
+                  {?TOKENS, gauge, "The number of available tokens"}]).
+
+%%====================================================================
+%% Collector API
+%%====================================================================
+
+deregister_cleanup(_) ->
+    ok.
+
+collect_mf(_Registry, Callback) ->
+    Stats = gather(),
+    [mf(Callback, Metric, Stats) || Metric <- ?METRICS],
+    ok.
+
+mf(Callback, {Name, Type, Help}, Stats) ->
+    Callback(create_mf(?METRIC_NAME(Name), Help, Type, ?MODULE,
+                       {Type, fun(S) -> maps:get(Name, S, undefined) end, Stats})),
+    ok.
+
+collect_metrics(_, {Type, Fun, Stats}) ->
+    case Fun(Stats) of
+        M when is_map(M) ->
+            [metric(Type, Labels, Value) || {Labels, Value} <- maps:to_list(M)];
+        _ ->
+            undefined
+    end.
+
+metric(gauge, Labels, Value) ->
+    gauge_metric(Labels, Value).
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+gather() ->
+    maps:fold(fun
+        (Name, #peer{outstanding = Outstanding,
+                     capacity = Capacity,
+                     rate = Rate,
+                     tokens = Tokens}, #{?OUTSTANDING := OutstandingMap, ?TOKENS := RateMap} = Stats) ->
+            Stats#{
+                ?OUTSTANDING := OutstandingMap#{[{name, Name}, {type, limit}] => Capacity, [{name, Name}, {type, used}] => Outstanding},
+                ?TOKENS      := RateMap#{[{name, Name}, {type, limit}] => Rate, [{name, Name}, {type, used}] => Tokens}
+            };
+        (_, _, Stats) ->
+            Stats
+    end, #{?OUTSTANDING => #{}, ?TOKENS => #{}}, ergw_aaa_diameter_srv:get_peers_info()).

--- a/test/diameter_Gy_SUITE.erl
+++ b/test/diameter_Gy_SUITE.erl
@@ -129,7 +129,8 @@ all() ->
      rate_limit,
      handle_failure,
      handle_answer_error,
-     handle_authorization_rejected].
+     handle_authorization_rejected,
+     diameter_metrics].
 
 init_per_suite(Config0) ->
     Config = [{handler_under_test, ?HUT} | Config0],
@@ -892,6 +893,14 @@ handle_authorization_rejected(Config) ->
     ?match(0, outstanding_reqs()),
     meck_validate(Config),
     ok.
+
+diameter_metrics() ->
+    [{doc, "check DIAMETER metrics"}].
+diameter_metrics(_Config) ->
+    ?equal(ok, prometheus_registry:register_collector(ergw_aaa, ergw_aaa_prometheus_collector)),
+    Metrics = prometheus_text_format:format(ergw_aaa),
+    ?match({match, _}, re:run(Metrics, "ergw_aaa_diameter_outstanding_requests")),
+    ?match({match, _}, re:run(Metrics, "ergw_aaa_diameter_available_tokens")).
 
 %%%======================================================================
 %%% Rate limit test helper to generate the requests in separate processes


### PR DESCRIPTION
**Example:** 
```
Metrics 
# TYPE ergw_aaa_diameter_outstanding_requests gauge
# HELP ergw_aaa_diameter_outstanding_requests The number of outstanding requests
ergw_aaa_diameter_outstanding_requests{name="server1.test-srv.example.com",type="limit"} 1
ergw_aaa_diameter_outstanding_requests{name="server1.test-srv.example.com",type="used"} 0
ergw_aaa_diameter_outstanding_requests{name="server2.test-srv.example.com",type="limit"} 1 
ergw_aaa_diameter_outstanding_requests{name="server2.test-srv.example.com",type="used"} 0
ergw_aaa_diameter_outstanding_requests{name="server3.test-srv.example.com",type="limit"} 1
ergw_aaa_diameter_outstanding_requests{name="server3.test-srv.example.com",type="used"} 0
ergw_aaa_diameter_outstanding_requests{name="server4.test-srv.example.com",type="limit"} 1
ergw_aaa_diameter_outstanding_requests{name="server4.test-srv.example.com",type="used"} 0
# TYPE ergw_aaa_diameter_available_tokens gauge
# HELP ergw_aaa_diameter_available_tokens The number of available tokens
ergw_aaa_diameter_available_tokens{name="server1.test-srv.example.com",type="limit"} 10
ergw_aaa_diameter_available_tokens{name="server1.test-srv.example.com",type="used"} 8
ergw_aaa_diameter_available_tokens{name="server2.test-srv.example.com",type="limit"} 10
ergw_aaa_diameter_available_tokens{name="server2.test-srv.example.com",type="used"} 9
ergw_aaa_diameter_available_tokens{name="server3.test-srv.example.com",type="limit"} 10
ergw_aaa_diameter_available_tokens{name="server3.test-srv.example.com",type="used"} 9
ergw_aaa_diameter_available_tokens{name="server4.test-srv.example.com",type="limit"} 10
ergw_aaa_diameter_available_tokens{name="server4.test-srv.example.com",type="used"} 9
```