### PR TITLE
Remove jobs from dependencies

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,6 @@
 
 {deps, [
 	{setup, "2.1.0"},
-	{jobs, "0.10.0"},
 	{prometheus, "4.6.0"},
 	{eradius, "2.2.1"},
 	{regine, "1.0.0"},


### PR DESCRIPTION
The "jobs" dependency is not used in "ergw_aaa"