### PR TITLE
Update prometheus to 4.8.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 
 {deps, [
 	{setup, "2.1.0"},
-	{prometheus, "4.6.0"},
+	{prometheus, "4.8.0"},
 	{eradius, "2.2.1"},
 	{regine, "1.0.0"},
 	{cut, "1.0.3"}


### PR DESCRIPTION
Diff hex.pm https://diff.hex.pm/diff/prometheus/4.6.0..4.8.0