### PR TITLE
Add Travelping dictionary

### DIFF
--- a/dia/diameter_3gpp_ts29_061_sgi.dia
+++ b/dia/diameter_3gpp_ts29_061_sgi.dia
@@ -24,6 +24,7 @@
 @inherits diameter_rfc4005_nasreq
 @inherits diameter_rfc4006_cc
 @inherits diameter_3gpp_base
+@inherits diameter_travelping
 
 @messages
 
@@ -171,6 +172,7 @@
               [ Redirect-Max-Cache-Time ]
             * [ Proxy-Info ]
               [ 3GPP-IPv6-DNS-Servers ]
+              [ TP-NAT-Pool-Id ]
             * [ AVP ]
 
       RAR ::= < Diameter Header: 258, REQ, PXY >
@@ -421,6 +423,10 @@
               [ 3GPP-Negotiated-DSCP ]
               [ TWAN-Identifier ]
               [ 3GPP-User-Location-Info-Time ]
+              [ TP-NAT-IP-Address ]
+              [ TP-NAT-Pool-Id ]
+              [ TP-NAT-Port-Start ]
+              [ TP-NAT-Port-End ]
             * [ AVP ]
 
       ACA ::= <Diameter Header: 271, PXY>

--- a/dia/diameter_3gpp_ts29_061_sgi_base_acc.dia
+++ b/dia/diameter_3gpp_ts29_061_sgi_base_acc.dia
@@ -24,6 +24,7 @@
 @inherits diameter_rfc4005_nasreq
 @inherits diameter_rfc4006_cc
 @inherits diameter_3gpp_base
+@inherits diameter_travelping
 
 @messages
 
@@ -131,6 +132,10 @@
               [ 3GPP-Negotiated-DSCP ]
               [ TWAN-Identifier ]
               [ 3GPP-User-Location-Info-Time ]
+              [ TP-NAT-IP-Address ]
+              [ TP-NAT-Pool-Id ]
+              [ TP-NAT-Port-Start ]
+              [ TP-NAT-Port-End ]
             * [ AVP ]
 
       ACA ::= <Diameter Header: 271, PXY>

--- a/dia/diameter_travelping.dia
+++ b/dia/diameter_travelping.dia
@@ -1,0 +1,20 @@
+;; Copyright 2021, Travelping GmbH <info@travelping.com>
+
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License
+;; as published by the Free Software Foundation; either version
+;; 2 of the License, or (at your option) any later version.
+
+;; It contains custom Travelping AVPs related to NAT-binding
+
+@id     1
+@name   diameter_travelping
+@prefix diameter_travelping
+@vendor 18681 Travelping
+
+@avp_types
+
+   TP-NAT-IP-Address             16    OctetString     V
+   TP-NAT-Pool-Id                27     UTF8String     V
+   TP-NAT-Port-Start             28     Unsigned32     V
+   TP-NAT-Port-End               29     Unsigned32     V


### PR DESCRIPTION
This commits adds Travelping diameter dictionary with custom AVPs
related to NAT-binding and extends NASREQ based dictionaries with
these custom AVPs.