### PR TITLE
stable/3.6: Fix parsing of Class RADIUS attribute

### DIFF
--- a/src/ergw_aaa_radius.erl
+++ b/src/ergw_aaa_radius.erl
@@ -384,8 +384,8 @@ radius_session_options(Type, RadiusSession, Attrs) ->
 
 radius_session_options(_, 'Class', [], Attrs) ->
     Attrs;
-radius_session_options(_, 'Class', [H|T], Attrs) ->
-    [{?Class, H}|radius_session_options('Class', T, Attrs)];
+radius_session_options(Type, 'Class', [H|T], Attrs) ->
+    [{?Class, H}|radius_session_options(Type, 'Class', T, Attrs)];
 radius_session_options(auth, 'RADIUS-State', State, Attrs) ->
     [{?State, State}|Attrs];
 radius_session_options(_, _Key, _Value, Attrs) ->


### PR DESCRIPTION
Same fix https://github.com/travelping/ergw_aaa/pull/140 but for `stable/3.6`.