### PR TITLE
Fix nodelay SCTP

### DIFF
--- a/src/ergw_aaa_diameter.erl
+++ b/src/ergw_aaa_diameter.erl
@@ -214,7 +214,7 @@ transport_config(sctp, Type, Raddr, Port, Opts0) ->
     Opts =
 	[Type, {raddr, Raddr}, {rport, Port}
 	| maps:to_list(maps:with([reuseaddr, recbuf, sndbuf, nodelay, unordered], Opts0))],
-    proplists:substitute_aliases([{nodelay, sctp_nodelay}], Opts).
+    proplists:unfold(proplists:substitute_aliases([{nodelay, sctp_nodelay}], Opts)).
 
 svc_set(Key, Value, Opts)
   when is_atom(Key), is_list(Value) ->


### PR DESCRIPTION
The previous implementation replaced a tuple to atom. Expected replace only key in `proplist` for `nodelay` key. 