### PR TITLE
add terminate step to all handlers

### DIFF
--- a/src/ergw_aaa_radius.erl
+++ b/src/ergw_aaa_radius.erl
@@ -146,11 +146,13 @@ invoke(_Service, start, Session0, Events, Opts, #{'State' := stopped} = State) -
 invoke(_Service, interim, Session, Events, Opts, #{'State' := started} = State) ->
     accounting(?RStatus_Type_Update, [], Session, Events, Opts, State);
 
-invoke(_Service, stop, Session, Events, Opts, #{'State' := started} = State) ->
+invoke(_Service, Procedure, Session, Events, Opts, #{'State' := started} = State)
+  when Procedure =:= stop; Procedure =:= terminate ->
     accounting(?RStatus_Type_Stop, [], Session, Events, Opts, State#{'State' => stopped});
 
 invoke(_Service, Procedure, Session, Events, _Opts, State)
-  when Procedure =:= start; Procedure =:= interim; Procedure =:= stop ->
+  when Procedure =:= start; Procedure =:= interim;
+       Procedure =:= stop; Procedure =:= terminate ->
     {ok, Session, Events, State};
 
 invoke(Service, Procedure, Session, Events, _Opts, State) ->

--- a/test/diameter_Gy_SUITE.erl
+++ b/test/diameter_Gy_SUITE.erl
@@ -172,10 +172,12 @@ end_per_suite(Config) ->
 init_per_testcase(_, Config) ->
     reset_session_stats(),
     meck_reset(Config),
+    ?match(0, outstanding_reqs()),
     Config.
 
 end_per_testcase(_, _Config) ->
     wait_for_outstanding_reqs(10),
+    ets:delete_all_objects(?MODULE),
     ok.
 
 %%%===================================================================
@@ -569,6 +571,10 @@ ccr_retry(Config) ->
     ?match(0, outstanding_reqs()),
     meck_validate(Config),
     ?CLEAR_TC_INFO(),
+
+    ets:delete_all_objects(?MODULE),
+    ?match(ok, ergw_aaa_session:terminate(SId)),
+    wait_for_session(ergw_aaa_ro, started, 0, 10),
     ok.
 
 rate_limit(_Config) ->

--- a/test/diameter_nasreq_SUITE.erl
+++ b/test/diameter_nasreq_SUITE.erl
@@ -79,7 +79,8 @@ common() ->
      attrs_3gpp,
      handle_failure,
      handle_answer_error,
-     abort_session_request].
+     abort_session_request,
+     terminate].
 
 groups() ->
     [{coupled, [], common()},
@@ -407,6 +408,40 @@ abort_session_request(Config) ->
     ?equal([{ergw_aaa_nasreq, started, 0}], get_session_stats()),
 
     %% make sure nothing crashed
+    ?match(0, outstanding_reqs()),
+    meck_validate(Config),
+    ok.
+
+terminate() ->
+    [{doc, "Simulate unexpected owner termiantion"}].
+terminate(Config) ->
+   Stats0 = get_stats(?SERVICE),
+
+    {ok, Session} = ergw_aaa_session_sup:new_session(
+		      self(),
+		      #{'Framed-IP-Address' => {10,10,10,10},
+			'Framed-IPv6-Prefix' => {{16#fe80,0,0,0,0,0,0,0}, 64},
+			'Framed-Pool' => <<"pool-A">>,
+			'Framed-IPv6-Pool' => <<"pool-A">>}),
+
+    {ok, _, _} = ergw_aaa_session:invoke(Session, #{}, authenticate, []),
+    ?match({ok, _, _}, ergw_aaa_session:invoke(Session, #{}, authorize, [])),
+    ?match({ok, _, _}, ergw_aaa_session:invoke(Session, #{}, start, [])),
+    ?equal([{ergw_aaa_nasreq, started, 1}], get_session_stats()),
+
+    ?match(ok, ergw_aaa_session:terminate(Session)),
+    wait_for_session(ergw_aaa_nasreq, started, 0, 10),
+
+
+    Statistics = diff_stats(Stats0, get_stats(?SERVICE)),
+
+    ct:pal("Statistics: ~p", [Statistics]),
+    [?equal(Cnt, stats(Msg, Config, Statistics)) ||
+	{Cnt, Msg} <- [{1, 'AAR'}, {1, {'AAA', 2001}},
+		       {2, 'ACR'}, {2, {'ACA', 2001}},
+		       {1, 'STR'}, {1, {'STA', 2001}}
+		      ]],
+
     ?match(0, outstanding_reqs()),
     meck_validate(Config),
     ok.

--- a/test/ergw_aaa_test_lib.hrl
+++ b/test/ergw_aaa_test_lib.hrl
@@ -27,5 +27,6 @@
 -import(ergw_aaa_test_lib, [meck_init/1, meck_reset/1, meck_unload/1, meck_validate/1,
 			    set_cfg_value/3, get_cfg_value/2,
 			    get_stats/1, diff_stats/2, wait_for_diameter/2,
-			    outstanding_reqs/0, get_session_stats/0, reset_session_stats/0]).
+			    outstanding_reqs/0, get_session_stats/0, wait_for_session/4,
+			    reset_session_stats/0]).
 -endif.


### PR DESCRIPTION
This makes sure that `stop`, STR or CCR-T is sent even when the session owner dies unexpectedly.

Fixes #134 