### PR TITLE
change answers in config from tuple to K/V

### DIFF
--- a/src/ergw_aaa.app.src
+++ b/src/ergw_aaa.app.src
@@ -16,6 +16,6 @@
 		 ]},
   {mod, { ergw_aaa_app, []}},
   {env, [{product_name, "erGW-AAA"},
-	 {rate_limits,  #{outstanding_requests => 50, rate => 50}}
+	 {rate_limits,  #{default => #{outstanding_requests => 50, rate => 50}}}
 	]}
  ]}.

--- a/src/ergw_aaa.erl
+++ b/src/ergw_aaa.erl
@@ -63,10 +63,10 @@ setopts(Opts0) when is_map(Opts0)->
 setopts(Opts) when is_list(Opts) ->
     setopts(ergw_aaa_config:to_map(Opts)).
 
-setopt(rate_limits = Opt, Value0) ->
-    Value = ergw_aaa_config:validate_options(
-	      fun ergw_aaa_config:validate_rate_limit/2, Value0, []),
-    application:set_env(ergw_aaa, Opt, Value);
+setopt(rate_limit = Opt, {Key, Value0}) ->
+    Value = ergw_aaa_config:validate_rate_limit(Key, Value0),
+    Limits = application:get_env(ergw_aaa, rate_limits, #{}),
+    application:set_env(ergw_aaa, rate_limits, maps:put(Key, Value, Limits));
 setopt(Opt, Value0) ->
     Value = ergw_aaa_config:validate_option(Opt, Value0),
     application:set_env(ergw_aaa, Opt, Value).

--- a/src/ergw_aaa_config.erl
+++ b/src/ergw_aaa_config.erl
@@ -13,7 +13,8 @@
 -export([validate_options/3,
 	 validate_option/2, validate_function/2,
 	 validate_handler/2, validate_service/2,
-	 validate_app/2, validate_rate_limit/2]).
+	 validate_app/2, validate_rate_limit/2,
+	 validate_answers/1]).
 -export([to_map/1]).
 
 -define(is_opts(X), (is_list(X) orelse is_map(X))).
@@ -161,3 +162,18 @@ validate_rate_limit_option(_RateLimit, rate, Rate)
     Rate;
 validate_rate_limit_option(RateLimit, Opt, Value) ->
     erlang:error(badarg, [RateLimit, Opt, Value]).
+
+validate_answers(Answers) when is_map(Answers) ->
+    maps:map(fun validate_answer/2, Answers).
+
+validate_answer(_, V) when is_map(V) ->
+    validate_options(fun validate_answer_opt/2, V, []);
+validate_answer(K, V) ->
+    erlang:error(badarg, [K, V]).
+
+validate_answer_opt(avps, AVPs) when is_map(AVPs) ->
+    AVPs;
+validate_answer_opt(state, ocs_hold = V) ->
+    V;
+validate_answer_opt(K, V) ->
+    erlang:error(badarg, [K, V]).

--- a/src/ergw_aaa_config.erl
+++ b/src/ergw_aaa_config.erl
@@ -149,8 +149,10 @@ validate_app_procs_svc(App, Procedure, Opts)
 validate_app_procs_svc(App, Procedure, Service) ->
     erlang:error(badarg, [App, Procedure, Service]).
 
-validate_rate_limit(RateLimit, Opts) when ?is_opts(Opts) ->
-    validate_options(validate_rate_limit_option(RateLimit, _, _), Opts, ?DefaultRateLimit);
+validate_rate_limit(K = default, Opts) when ?is_opts(Opts) ->
+    validate_options(validate_rate_limit_option(K, _, _), Opts, ?DefaultRateLimit);
+validate_rate_limit(Peer, Opts) when is_binary(Peer), ?is_opts(Opts) ->
+    validate_options(validate_rate_limit_option(Peer, _, _), Opts, ?DefaultRateLimit);
 validate_rate_limit(RateLimit, Opts) ->
     erlang:error(badarg, [RateLimit, Opts]).
 

--- a/src/ergw_aaa_diameter_srv.erl
+++ b/src/ergw_aaa_diameter_srv.erl
@@ -301,13 +301,13 @@ get_peer(Host, Peers) ->
 	    true ->
 		maps:get(Host, Peers);
 	    _ ->
-		RateLimits = application:get_env(ergw_aaa, rate_limits, #{}),
 		#{outstanding_requests := Capacity, rate := Rate} =
-		    if is_map_key(Host, RateLimits) ->
-			    maps:get(Host, RateLimits);
-		       is_map_key(default, RateLimits) ->
-			    maps:get(default, RateLimits);
-		       true ->
+		    case application:get_env(ergw_aaa, rate_limits, undefined) of
+			Limits when is_map_key(Host, Limits) ->
+			    maps:get(Host, Limits);
+			#{default := Default} ->
+			    Default;
+			_ ->
 			    #{outstanding_requests => 50, rate => 50}
 		    end,
 		#peer{capacity = Capacity, rate = Rate}

--- a/src/ergw_aaa_static.erl
+++ b/src/ergw_aaa_static.erl
@@ -43,7 +43,12 @@ validate_procedure(_Application, _Procedure, _Service, ServiceOpts, Opts) ->
     ergw_aaa_config:validate_options(fun validate_option/2, Opts, ServiceOpts).
 
 invoke(_Service, Procedure, Session, Events, #{answers := Answers, answer := Answer}, State) ->
-    handle_response(Procedure, maps:get(Answer, Answers, #{}), Session, Events, State);
+    AVPs =
+	case Answers of
+	    #{Answer := #{avps := A}} -> A;
+	    _ -> #{}
+	end,
+    handle_response(Procedure, AVPs, Session, Events, State);
 invoke(_Service, _Procedure, Session, Events, Opts, State) ->
     SOpts = maps:get(defaults, Opts, #{}),
     {ok, maps:merge(Session, SOpts), Events, State}.
@@ -63,7 +68,7 @@ validate_option(handler, Value) ->
 validate_option(service, Value) ->
     Value;
 validate_option(answers, Value) when is_map(Value) ->
-    Value;
+    ergw_aaa_config:validate_answers(Value);
 validate_option(answer, Value) ->
     Value;
 validate_option(defaults, Opts) when ?is_opts(Opts) ->

--- a/test/config_SUITE.erl
+++ b/test/config_SUITE.erl
@@ -41,7 +41,7 @@
 	 }).
 
 -define(RADIUS_AUTH_CONFIG,
-	#{server                    => #{server => {127,0,0,1},
+	#{server                    => #{host => {127,0,0,1},
 					 port => 1812,
 					 secret => <<"secret">>},
 	  retries                   => 3,
@@ -50,7 +50,7 @@
 	  avp_filter                => #{},
 	  termination_cause_mapping => ?RADIUS_DEFAULT_TERMINATION_CAUSE_MAPPING}).
 -define(RADIUS_ACCT_CONFIG,
-	#{server                    => #{server => {0,0,0,0,0,0,0,1},
+	#{server                    => #{host => {0,0,0,0,0,0,0,1},
 					 port => 1813,
 					 secret => <<"secret">>},
 	  retries                   => 3,
@@ -279,7 +279,8 @@ radius_handler(_Config)  ->
     ?bad(ValF(set_cfg_value([retries], invalid, Cfg))),
     ?bad(ValF(set_cfg_value([timeout], invalid, Cfg))),
 
-    ?ok(ValF(set_cfg_value([server], #{server => "localhost", port => 1812, secret => <<"secret">>}, Cfg))),
+    ?ok(ValF(set_cfg_value([server], #{host => "localhost", port => 1812, secret => <<"secret">>}, Cfg))),
+    ?ok(ValF(set_cfg_value([server], #{host => <<"localhost">>, port => 1812, secret => <<"secret">>}, Cfg))),
     ?ok(ValF(set_cfg_value([async], true, Cfg))),
     ?ok(ValF(set_cfg_value([async], false, Cfg))),
     ?ok(ValF(set_cfg_value([retries], 1, Cfg))),

--- a/test/diameter_Gy_SUITE.erl
+++ b/test/diameter_Gy_SUITE.erl
@@ -76,17 +76,21 @@
 		    #{handler => 'ergw_aaa_ro',
 		      answers =>
 			  #{<<"OCS-Hold">> =>
-				{ocs_hold,
-				 [#{'Envelope-Reporting' => [0],
-				    'Granted-Service-Unit' =>
-					[#{'CC-Time-Min' => [1800], 'CC-Time-Max' => [1900]}],
-				    'Rating-Group' => [1000],
-				    'Result-Code' => [2001],
-				    'Time-Quota-Threshold' => [60]}
-				 ]
-				}
-			   }}
-		     },
+				#{avps =>
+				      #{'Result-Code' => 2001,
+					'Multiple-Services-Credit-Control' =>
+					    [#{'Envelope-Reporting' => [0],
+					       'Granted-Service-Unit' =>
+						   [#{'CC-Time-Min' => [1800],
+						      'CC-Time-Max' => [1900]}],
+					       'Rating-Group' => [1000],
+					       'Result-Code' => [2001],
+					       'Time-Quota-Threshold' => [60]}]},
+				  state => ocs_hold
+				 }
+			   }
+		     }
+	       },
 	  apps =>
 	      #{default =>
 		    #{init => [#{service => <<"Default">>}],

--- a/test/diameter_avp_filter_SUITE.erl
+++ b/test/diameter_avp_filter_SUITE.erl
@@ -70,7 +70,7 @@
 
 -define(CONFIG,
 	#{rate_limits =>
-	      #{<<"default">> => #{outstanding_requests => 10, rate => 10}},
+	      #{default => #{outstanding_requests => 50, rate => 50}},
 	  functions => ?DIAMETER_FUNCTION,
 	  handlers =>
 	      #{ergw_aaa_static => ?STATIC_CONFIG,

--- a/test/diameter_nasreq_SUITE.erl
+++ b/test/diameter_nasreq_SUITE.erl
@@ -44,7 +44,7 @@
 
 -define(CONFIG,
 	#{rate_limits =>
-	      #{<<"default">> => #{outstanding_requests => 10, rate => 1000}},
+	      #{default => #{outstanding_requests => 10, rate => 1000}},
 	  functions => ?DIAMETER_FUNCTION,
 	  handlers =>
 	      #{ergw_aaa_static => ?STATIC_CONFIG,

--- a/test/ergw_aaa_test_lib.erl
+++ b/test/ergw_aaa_test_lib.erl
@@ -103,10 +103,10 @@ ergw_aaa_init(Config) ->
 ergw_aaa_init(product_name, #{product_name := PN0}) ->
     PN = ergw_aaa_config:validate_option(product_name, PN0),
     ergw_aaa:setopt(product_name, PN);
-ergw_aaa_init(rate_limits, #{rate_limits := Limits0}) ->
-    Limits = ergw_aaa_config:validate_options(
-	       fun ergw_aaa_config:validate_rate_limit/2, Limits0, []),
-    ergw_aaa:setopt(rate_limits, Limits);
+ergw_aaa_init(rate_limits, #{rate_limits := Limits}) when is_list(Limits) ->
+    lists:foreach(ergw_aaa:setopt(rate_limit, _), Limits);
+ergw_aaa_init(rate_limits, #{rate_limits := Limits}) when is_map(Limits) ->
+    lists:foreach(ergw_aaa:setopt(rate_limit, _), maps:to_list(Limits));
 ergw_aaa_init(handlers, #{handlers := Handlers0}) ->
     Handlers = ergw_aaa_config:validate_options(
 		 fun ergw_aaa_config:validate_handler/2, Handlers0, []),

--- a/test/radius_SUITE.erl
+++ b/test/radius_SUITE.erl
@@ -28,7 +28,7 @@
 
 -define(RADIUS_CONFIG,
 	#{server =>
-	      #{server => {127,0,0,1},
+	      #{host => {127,0,0,1},
 		port => 1812,
 		secret => <<"secret">>}}).
 
@@ -44,13 +44,13 @@
 		<<"RADIUS-Auth">> =>
 		    #{handler => 'ergw_aaa_radius',
 		      server =>
-			  #{server => {127,0,0,1},
+			  #{host => {127,0,0,1},
 			    port => 1812,
 			    secret => <<"secret">>}},
 		<<"RADIUS-Acct">> =>
 		    #{handler => 'ergw_aaa_radius',
 		      server =>
-			  #{server => {127,0,0,1},
+			  #{host => {127,0,0,1},
 			    port => 1813,
 			    secret => <<"secret">>}}},
 	  apps =>

--- a/test/radius_SUITE.erl
+++ b/test/radius_SUITE.erl
@@ -34,7 +34,7 @@
 
 -define(CONFIG,
 	#{rate_limits =>
-	      #{<<"default">> => #{outstanding_requests => 10, rate => 1000}},
+	      #{default => #{outstanding_requests => 50, rate => 1000}},
 	  handlers =>
 	      #{ergw_aaa_static => ?STATIC_CONFIG,
 		ergw_aaa_radius => ?RADIUS_CONFIG},

--- a/test/static_SUITE.erl
+++ b/test/static_SUITE.erl
@@ -35,54 +35,61 @@
 		    #{handler => 'ergw_aaa_static',
 		      answers =>
 			  #{<<"Initial-Gy">> =>
-				#{'Result-Code' => 2001,
-				  'Multiple-Services-Credit-Control' =>
-				      [#{'Envelope-Reporting' => [0],
-					 'Granted-Service-Unit' =>
-					     [#{'CC-Time' => [3600],
-						'CC-Total-Octets' => [102400]}],
-					 'Rating-Group' => [3000],
-					 'Result-Code' => [2001],
-					 'Time-Quota-Threshold' => [60],
-					 'Volume-Quota-Threshold' => [10240]}
-				      ]
+				#{avps =>
+				      #{'Result-Code' => 2001,
+					'Multiple-Services-Credit-Control' =>
+					    [#{'Envelope-Reporting' => [0],
+					       'Granted-Service-Unit' =>
+						   [#{'CC-Time' => [3600],
+						      'CC-Total-Octets' => [102400]}],
+					       'Rating-Group' => [3000],
+					       'Result-Code' => [2001],
+					       'Time-Quota-Threshold' => [60],
+					       'Volume-Quota-Threshold' => [10240]}
+					    ]
+				       }
 				 },
 			    <<"Update-Gy">> =>
-				#{'Result-Code' => 5003},
+				#{avps => #{'Result-Code' => 5003}},
 			    <<"Initial-Gx">> =>
-				#{'Result-Code' => 2001,
-				  'Charging-Rule-Install' =>
-				      [#{'Charging-Rule-Definition' =>
-					     [#{'Charging-Rule-Name' => <<"m2m-gx">>,
-						'Rating-Group' => [3000],
-						'Flow-Information' =>
-						    [#{'Flow-Description' => [<<"permit out ip from any to assigned">>],
-						       'Flow-Direction'   => [1]    %% DownLink
-						      },
-						     #{'Flow-Description' => [<<"permit out ip from any to assigned">>],
-						       'Flow-Direction'   => [2]    %% UpLink
-						      }],
-						'Metering-Method'  => [1],
-						'Precedence' => [100]
-					       }],
-					 'Charging-Rule-Name' =>
-					     [<<"m2m-r0001">>, <<"m2m-r0001">>],
-					 'Charging-Rule-Base-Name' =>
-					     [<<"m2m0001">>]
-					}
-				      ]
+				#{avps =>
+				      #{'Result-Code' => 2001,
+					'Charging-Rule-Install' =>
+					    [#{'Charging-Rule-Definition' =>
+						   [#{'Charging-Rule-Name' => <<"m2m-gx">>,
+						      'Rating-Group' => [3000],
+						      'Flow-Information' =>
+							  [#{'Flow-Description' => [<<"permit out ip from any to assigned">>],
+							     'Flow-Direction'   => [1]    %% DownLink
+							    },
+							   #{'Flow-Description' => [<<"permit out ip from any to assigned">>],
+							     'Flow-Direction'   => [2]    %% UpLink
+							    }],
+						      'Metering-Method'  => [1],
+						      'Precedence' => [100]
+						     }],
+					       'Charging-Rule-Name' =>
+						   [<<"m2m-r0001">>, <<"m2m-r0001">>],
+					       'Charging-Rule-Base-Name' =>
+						   [<<"m2m0001">>]
+					      }
+					    ]
+				       }
 				 },
 			    <<"Update-Gx">> =>
-				#{'Result-Code' => 2001,
-				  'Charging-Rule-Remove' =>
-				      [#{'Charging-Rule-Name' =>
-					     [<<"m2m-r0001">>],
-					 'Charging-Rule-Base-Name' =>
-					     [<<"m2m0001">>]
-					}
-				      ]
+				#{avps =>
+				      #{'Result-Code' => 2001,
+					'Charging-Rule-Remove' =>
+					    [#{'Charging-Rule-Name' =>
+						   [<<"m2m-r0001">>],
+					       'Charging-Rule-Base-Name' =>
+						   [<<"m2m0001">>]
+					      }
+					    ]
+				       }
 				 },
-			    <<"Final-Gx">> => #{'Result-Code' => 5003}
+			    <<"Final-Gx">> =>
+				#{avps => #{'Result-Code' => 5003}}
 			   }
 		     }
 	       },


### PR DESCRIPTION
The Gy API was using a special construct to deal with adjustments
to the Multiple-Services-Credit-Control AVP in fake answers.

Replace that with a state identifier and plain AVPs.