### PR TITLE
handle structured User-Location-Info data

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,8 @@
 	{prometheus, "4.8.1"},
 	{eradius, "2.2.2"},
 	{regine, "1.0.0"},
-	{cut, "1.0.3"}
+	{cut, "1.0.3"},
+	{gtplib, "3.0.0"}
 ]}.
 
 {minimum_otp_vsn, "21.3"}.

--- a/src/ergw_aaa_3gpp_dict.erl
+++ b/src/ergw_aaa_3gpp_dict.erl
@@ -46,6 +46,7 @@
 %% - 3GPP-SGSN-Ipv6-Address
 %% - 3GPP-GGSN-Ipv6-Address
 
+-include_lib("gtplib/include/gtp_packet.hrl").
 
 %%====================================================================
 %% IP Address helpers
@@ -109,6 +110,59 @@ encode('3GPP-Allocate-IP-Type', Value) when is_integer(Value) ->
 encode('3GPP-Secondary-RAT-Usage', {RAT, Start, Stop, DL, UL}) ->
     <<0:4, RAT:4, Start:32, Stop:32, DL:64, UL:64>>;
 
+%% 3GPP-User-Location-Info
+%%
+%% types from 3GPP TS 29.061, Rel. 16.2:
+%%  0        CGI
+%%  1        SAI
+%%  2        RAI
+%%  3-127    Spare for future use
+%%  128      TAI
+%%  129      ECGI
+%%  130      TAI and ECGI
+%%  131      eNodeB ID
+%%  132      TAI and eNodeB ID
+%%  133      extended eNodeB ID
+%%  134      TAI and extended eNodeB ID
+%%  135      NCGI
+%%  136      5GS TAI
+%%  137      5GS TAI and NCGI
+%%  138      NG-RAN Node ID
+%%  139      5GS TAI and NG-RAN Node ID
+%%  140-255  Spare for future use
+encode('User-Location-Info', #{'TAI' := TAI, 'ext-macro-eNB' := EMeNB})
+  when is_record(TAI, tai), is_record(EMeNB, ext_macro_enb) ->
+    <<134, (encode_tai(TAI))/binary, (encode_ext_macro_enb(EMeNB))/binary>>;
+encode('User-Location-Info', #{'ext-macro-eNB' := EMeNB})
+  when is_record(EMeNB, ext_macro_enb) ->
+    <<133, (encode_ext_macro_enb(EMeNB))/binary>>;
+encode('User-Location-Info', #{'TAI' := TAI, 'macro-eNB' := MeNB})
+  when is_record(TAI, tai), is_record(MeNB, macro_enb) ->
+    <<132, (encode_tai(TAI))/binary, (encode_macro_enb(MeNB))/binary>>;
+encode('User-Location-Info', #{'macro-eNB' := MeNB})
+  when is_record(MeNB, macro_enb) ->
+    <<131, (encode_macro_enb(MeNB))/binary>>;
+encode('User-Location-Info', #{'TAI' := TAI, 'ECGI' := ECGI})
+  when is_record(TAI, tai), is_record(ECGI, ecgi) ->
+    <<130, (encode_tai(TAI))/binary, (encode_ecgi(ECGI))/binary>>;
+encode('User-Location-Info', #{'ECGI' := ECGI})
+  when is_record(ECGI, ecgi) ->
+    <<129, (encode_ecgi(ECGI))/binary>>;
+encode('User-Location-Info', #{'TAI' := TAI})
+  when is_record(TAI, tai) ->
+    <<128, (encode_tai(TAI))/binary>>;
+encode('User-Location-Info', #{'RAI' := RAI})
+  when is_record(RAI, rai) ->
+    <<2, (encode_rai(RAI))/binary>>;
+encode('User-Location-Info', #{'SAI' := SAI})
+  when is_record(SAI, sai) ->
+    <<1, (encode_sai(SAI))/binary>>;
+encode('User-Location-Info', #{'CGI' := CGI})
+  when is_record(CGI, cgi) ->
+    <<0, (encode_cgi(CGI))/binary>>;
+encode('User-Location-Info', _Value) ->
+    <<>>;
+
 encode(_Key, Value) ->
     Value.
 
@@ -130,3 +184,30 @@ decode(_Key, Value) ->
 
 hexstr(Value) when is_binary(Value) ->
     iolist_to_binary([io_lib:format("~2.16.0B", [X]) || <<X>> <= Value]).
+
+encode_cgi(#cgi{plmn_id = PLMN, lac = LAC, ci = CI}) ->
+    <<(gtp_packet:encode_plmn_id(PLMN))/binary, LAC:16, CI:16>>.
+
+encode_sai(#sai{plmn_id = PLMN, lac = LAC, sac = SAC}) ->
+    <<(gtp_packet:encode_plmn_id(PLMN))/binary, LAC:16, SAC:16>>.
+
+encode_rai(#rai{plmn_id = PLMN, lac = LAC, rac = RAC}) ->
+    <<(gtp_packet:encode_plmn_id(PLMN))/binary, LAC:16, RAC:16>>.
+
+encode_tai(#tai{plmn_id = PLMN, tac = TAC}) ->
+    <<(gtp_packet:encode_plmn_id(PLMN))/binary, TAC:16>>.
+
+encode_ecgi(#ecgi{plmn_id = PLMN, eci = ECI}) ->
+    <<(gtp_packet:encode_plmn_id(PLMN))/binary, 0:4, ECI:28>>.
+
+%% encode_lai(#lai{plmn_id = PLMN, lac = LAC}) ->
+%%     <<(gtp_packet:encode_plmn_id(PLMN))/binary, LAC:16>>.
+
+encode_macro_enb(#macro_enb{plmn_id = PLMN, id = Id}) ->
+    <<(gtp_packet:encode_plmn_id(PLMN))/binary, 0:4, Id:20>>.
+
+encode_ext_macro_enb(#ext_macro_enb{plmn_id = PLMN, id = Id})
+  when Id =< 16#03ffff ->
+    <<(gtp_packet:encode_plmn_id(PLMN))/binary, 0:1, 0:5, Id:18>>;
+encode_ext_macro_enb(#ext_macro_enb{plmn_id = PLMN, id = Id}) ->
+    <<(gtp_packet:encode_plmn_id(PLMN))/binary, 1:1, 0:2, Id:21>>.

--- a/src/ergw_aaa_diameter.erl
+++ b/src/ergw_aaa_diameter.erl
@@ -301,6 +301,13 @@ build_transport_caps(_, _, Caps) ->
        Key =:= '3GPP-Secondary-RAT-Usage' ->
     ergw_aaa_3gpp_dict:encode(Key, Value);
 
+'3gpp_from_session'('3GPP-User-Location-Info', Value)
+  when is_binary(Value) ->
+    Value;
+'3gpp_from_session'('User-Location-Info' = Key, Value)
+  when is_map(Value) ->
+    ergw_aaa_3gpp_dict:encode(Key, Value);
+
 '3gpp_from_session'(Key, Value)
   when Key =:= '3GPP-Charging-Id';
        Key =:= '3GPP-Camel-Charging';
@@ -309,7 +316,6 @@ build_transport_caps(_, _, Caps) ->
        Key =:= '3GPP-GGSN-MCC-MNC';
        Key =:= '3GPP-SGSN-MCC-MNC';
        Key =:= '3GPP-IMEISV';
-       Key =:= '3GPP-User-Location-Info';
        Key =:= '3GPP-Packet-Filter';
        Key =:= '3GPP-Negotiated-DSCP' ->
     Value.

--- a/src/ergw_aaa_gx.erl
+++ b/src/ergw_aaa_gx.erl
@@ -484,9 +484,14 @@ from_session(Key, Value, Avps)
        Key =:= '3GPP-Charging-Characteristics';
        Key =:= '3GPP-SGSN-MCC-MNC';
        Key =:= '3GPP-MS-TimeZone';
-       Key =:= '3GPP-User-Location-Info';
        Key =:= '3GPP-RAT-Type' ->
     Avps#{Key => [ergw_aaa_diameter:'3gpp_from_session'(Key, Value)]};
+
+%% '3GPP-User-Location-Info'
+from_session(Key, Value, Avps)
+  when Key =:= 'User-Location-Info';
+       Key =:= '3GPP-User-Location-Info' ->
+    Avps#{'3GPP-User-Location-Info' => [ergw_aaa_diameter:'3gpp_from_session'(Key, Value)]};
 
 %% 'AN-Trusted'
 %% 'RAT-Type'

--- a/src/ergw_aaa_nasreq.erl
+++ b/src/ergw_aaa_nasreq.erl
@@ -477,10 +477,15 @@ from_session(Key, Value, M)
        Key =:= '3GPP-GGSN-MCC-MNC';
        Key =:= '3GPP-SGSN-MCC-MNC';
        Key =:= '3GPP-IMEISV';
-       Key =:= '3GPP-User-Location-Info';
        Key =:= '3GPP-Packet-Filter';
        Key =:= '3GPP-Negotiated-DSCP' ->
     M#{Key => [ergw_aaa_diameter:'3gpp_from_session'(Key, Value)]};
+
+%% '3GPP-User-Location-Info'
+from_session(Key, Value, M)
+  when Key =:= 'User-Location-Info';
+       Key =:= '3GPP-User-Location-Info' ->
+    M#{'3GPP-User-Location-Info' => [ergw_aaa_diameter:'3gpp_from_session'(Key, Value)]};
 
 from_session('Service-Type' = Key, Value, M) ->
     M#{Key => [service_type(Value)]};

--- a/src/ergw_aaa_radius.erl
+++ b/src/ergw_aaa_radius.erl
@@ -559,8 +559,10 @@ session_options('3GPP-IMEISV', Value, Attrs) ->
     [{?X_3GPP_IMEISV, Value}|Attrs];
 session_options('3GPP-RAT-Type' = Key, Value, Attrs) ->
     [{?X_3GPP_RAT_Type, ergw_aaa_3gpp_dict:encode(Key, Value)}|Attrs];
-session_options('3GPP-User-Location-Info', Value, Attrs) ->
+session_options('3GPP-User-Location-Info', Value, Attrs) when is_binary(Value) ->
     [{?X_3GPP_User_Location_Info, Value}|Attrs];
+session_options('User-Location-Info' = Key, Value, Attrs) when is_map(Value) ->
+    [{?X_3GPP_User_Location_Info, ergw_aaa_3gpp_dict:encode(Key, Value)}|Attrs];
 session_options('3GPP-MS-TimeZone' = Key, Value, Attrs) ->
     [{?X_3GPP_MS_TimeZone, ergw_aaa_3gpp_dict:encode(Key, Value)}|Attrs];
 session_options('3GPP-Camel-Charging', Value, Attrs) ->

--- a/src/ergw_aaa_rf.erl
+++ b/src/ergw_aaa_rf.erl
@@ -480,7 +480,6 @@ from_session('Diameter-Session-Id', SId, M) ->
 %% '3GPP-Charging-Characteristics'
 %% '3GPP-SGSN-MCC-MNC'
 %% '3GPP-MS-TimeZone'
-%% '3GPP-User-Location-Info'
 %% '3GPP-RAT-Type'
 from_session(Key, Value, Avps)
   when Key =:= '3GPP-PDP-Type';
@@ -491,9 +490,15 @@ from_session(Key, Value, Avps)
        Key =:= '3GPP-Charging-Characteristics';
        Key =:= '3GPP-SGSN-MCC-MNC';
        Key =:= '3GPP-MS-TimeZone';
-       Key =:= '3GPP-User-Location-Info';
        Key =:= '3GPP-RAT-Type' ->
     optional([?SI_PSI, Key], ergw_aaa_diameter:'3gpp_from_session'(Key, Value), Avps);
+
+%% '3GPP-User-Location-Info'
+from_session(Key, Value, Avps)
+  when Key =:= 'User-Location-Info';
+       Key =:= '3GPP-User-Location-Info' ->
+    optional([?SI_PSI, '3GPP-User-Location-Info'],
+	     ergw_aaa_diameter:'3gpp_from_session'(Key, Value), Avps);
 
 from_session('3GPP-IMSI', IMSI, Avps) ->
     SI = #{'Subscription-Id-Type' => ?'DIAMETER_RF_SUBSCRIPTION-ID-TYPE_END_USER_IMSI',

--- a/src/ergw_aaa_ro.erl
+++ b/src/ergw_aaa_ro.erl
@@ -492,7 +492,6 @@ from_session('3GPP-Charging-Id' = Key, Value, Avps0) ->
 %% '3GPP-Charging-Characteristics'
 %% '3GPP-SGSN-MCC-MNC'
 %% '3GPP-MS-TimeZone'
-%% '3GPP-User-Location-Info'
 %% '3GPP-RAT-Type'
 from_session(Key, Value, Avps)
   when Key =:= '3GPP-PDP-Type';
@@ -503,9 +502,15 @@ from_session(Key, Value, Avps)
        Key =:= '3GPP-Charging-Characteristics';
        Key =:= '3GPP-SGSN-MCC-MNC';
        Key =:= '3GPP-MS-TimeZone';
-       Key =:= '3GPP-User-Location-Info';
        Key =:= '3GPP-RAT-Type' ->
     optional([?SI_PSI, Key], ergw_aaa_diameter:'3gpp_from_session'(Key, Value), Avps);
+
+%% '3GPP-User-Location-Info'
+from_session(Key, Value, Avps)
+  when Key =:= 'User-Location-Info';
+       Key =:= '3GPP-User-Location-Info' ->
+    optional([?SI_PSI, '3GPP-User-Location-Info'],
+	     ergw_aaa_diameter:'3gpp_from_session'(Key, Value), Avps);
 
 %% Add '3GPP-IMSI' to both places commonly used : in the AVP root (e.g. Nokia) and in 
 %% 'Subscription-Id' (3GPP) then filter out the one you don't need with AVP filter

--- a/test/diameter_Gx_SUITE.erl
+++ b/test/diameter_Gx_SUITE.erl
@@ -19,6 +19,7 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("diameter/include/diameter_gen_base_rfc6733.hrl").
+-include_lib("gtplib/include/gtp_packet.hrl").
 -include("../include/diameter_3gpp_ts29_212.hrl").
 -include("../include/ergw_aaa_session.hrl").
 -include("ergw_aaa_test_lib.hrl").
@@ -148,7 +149,13 @@ init_session(Session, _Config) ->
 	  '3GPP-SGSN-Address'       => {192,168,1,1},
 	  '3GPP-SGSN-MCC-MNC'       => <<"26201">>,
 	  '3GPP-Selection-Mode'     => 0,
-	  '3GPP-User-Location-Info' => <<24,98,242,16,64,163,98,242,16,1,156,232,0>>,
+	  'User-Location-Info' =>
+	      #{'ext-macro-eNB' =>
+		    #ext_macro_enb{plmn_id = {<<"001">>, <<"001">>},
+				   id = rand:uniform(16#1fffff)},
+		'TAI' =>
+		    #tai{plmn_id = {<<"001">>, <<"001">>},
+			 tac = rand:uniform(16#ffff)}},
 	  'Called-Station-Id'       => <<"some.station.gprs">>,
 	  %% 'Calling-Station-Id'      => <<"543148000012345">>,
 	  'Framed-IP-Address'       => {10,106,14,227},

--- a/test/diameter_Gy_SUITE.erl
+++ b/test/diameter_Gy_SUITE.erl
@@ -13,6 +13,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("diameter/include/diameter_gen_base_rfc6733.hrl").
 -include_lib("diameter/include/diameter.hrl").
+-include_lib("gtplib/include/gtp_packet.hrl").
 -include("../include/diameter_3gpp_ts32_299.hrl").
 -include("../include/ergw_aaa_session.hrl").
 -include("ergw_aaa_test_lib.hrl").
@@ -205,7 +206,13 @@ init_session(Session, _Config) ->
 	  '3GPP-SGSN-Address'       => {192,168,1,1},
 	  '3GPP-SGSN-MCC-MNC'       => <<"26201">>,
 	  '3GPP-Selection-Mode'     => 0,
-	  '3GPP-User-Location-Info' => <<24,98,242,16,64,163,98,242,16,1,156,232,0>>,
+	  'User-Location-Info' =>
+	      #{'ext-macro-eNB' =>
+		    #ext_macro_enb{plmn_id = {<<"001">>, <<"001">>},
+				   id = rand:uniform(16#1fffff)},
+		'TAI' =>
+		    #tai{plmn_id = {<<"001">>, <<"001">>},
+			 tac = rand:uniform(16#ffff)}},
 	  'Called-Station-Id'       => <<"some.station.gprs">>,
 	  'Calling-Station-Id'      => <<"543148000012345">>,
 	  'Framed-IP-Address'       => {10,106,14,227},

--- a/test/diameter_Rf_SUITE.erl
+++ b/test/diameter_Rf_SUITE.erl
@@ -13,6 +13,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("diameter/include/diameter.hrl").
 -include_lib("diameter/include/diameter_gen_base_rfc6733.hrl").
+-include_lib("gtplib/include/gtp_packet.hrl").
 -include("../include/diameter_3gpp_ts32_299.hrl").
 -include("../include/diameter_3gpp_ts32_299_rf.hrl").
 -include("../include/ergw_aaa_session.hrl").
@@ -147,7 +148,13 @@ init_session(Session, _Config) ->
 	  '3GPP-SGSN-Address'       => {192,168,1,1},
 	  '3GPP-SGSN-MCC-MNC'       => <<"26201">>,
 	  '3GPP-Selection-Mode'     => 0,
-	  '3GPP-User-Location-Info' => <<24,98,242,16,64,163,98,242,16,1,156,232,0>>,
+	  'User-Location-Info' =>
+	      #{'ext-macro-eNB' =>
+		    #ext_macro_enb{plmn_id = {<<"001">>, <<"001">>},
+				   id = rand:uniform(16#1fffff)},
+		'TAI' =>
+		    #tai{plmn_id = {<<"001">>, <<"001">>},
+			 tac = rand:uniform(16#ffff)}},
 	  'Called-Station-Id'       => <<"some.station.gprs">>,
 	  'Calling-Station-Id'      => <<"543148000012345">>,
 	  'Framed-IP-Address'       => {10,106,14,227},

--- a/test/diameter_nasreq_SUITE.erl
+++ b/test/diameter_nasreq_SUITE.erl
@@ -12,6 +12,7 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("diameter/include/diameter_gen_base_rfc6733.hrl").
+-include_lib("gtplib/include/gtp_packet.hrl").
 -include("../include/ergw_aaa_session.hrl").
 -include("ergw_aaa_test_lib.hrl").
 
@@ -254,7 +255,13 @@ attrs_3gpp(Config) ->
 	      '3GPP-SGSN-IPv6-Address'  => {16#fd96, 16#dcd2, 16#efdb, 16#41c4, 0, 0, 0, 16#1000},
 	      '3GPP-GGSN-IPv6-Address'  => {16#fd96, 16#dcd2, 16#efdb, 16#41c4, 0, 0, 0, 16#2000},
 	      '3GPP-Selection-Mode'     => 0,
-	      '3GPP-User-Location-Info' => <<24,98,242,16,64,163,98,242,16,1,156,232,0>>,
+	      'User-Location-Info' =>
+		  #{'ext-macro-eNB' =>
+			#ext_macro_enb{plmn_id = {<<"001">>, <<"001">>},
+				       id = rand:uniform(16#1fffff)},
+		    'TAI' =>
+			#tai{plmn_id = {<<"001">>, <<"001">>},
+			     tac = rand:uniform(16#ffff)}},
 	      'Called-Station-Id'       => <<"some.station.gprs">>,
 	      'Calling-Station-Id'      => <<"543148000012345">>,
 	      'Framed-IP-Address'       => {0,0,0,0},

--- a/test/radius_SUITE.erl
+++ b/test/radius_SUITE.erl
@@ -15,6 +15,7 @@
 -include_lib("eradius/include/dictionary.hrl").
 -include_lib("eradius/include/dictionary_ituma.hrl").
 -include_lib("diameter/include/diameter_gen_base_rfc6733.hrl").
+-include_lib("gtplib/include/gtp_packet.hrl").
 -include("ergw_aaa_test_lib.hrl").
 
 -define(HUT, ergw_aaa_radius).
@@ -246,7 +247,13 @@ attrs_3gpp(Config) ->
 	      '3GPP-SGSN-IPv6-Address'  => {16#fd96, 16#dcd2, 16#efdb, 16#41c4, 0, 0, 0, 16#1000},
 	      '3GPP-GGSN-IPv6-Address'  => {16#fd96, 16#dcd2, 16#efdb, 16#41c4, 0, 0, 0, 16#2000},
 	      '3GPP-Selection-Mode'     => 0,
-	      '3GPP-User-Location-Info' => <<24,98,242,16,64,163,98,242,16,1,156,232,0>>,
+	      'User-Location-Info' =>
+		  #{'ext-macro-eNB' =>
+			#ext_macro_enb{plmn_id = {<<"001">>, <<"001">>},
+				       id = rand:uniform(16#1fffff)},
+		    'TAI' =>
+			#tai{plmn_id = {<<"001">>, <<"001">>},
+			     tac = rand:uniform(16#ffff)}},
 	      'Called-Station-Id'       => <<"some.station.gprs">>,
 	      'Calling-Station-Id'      => <<"543148000012345">>,
 	      'Framed-IP-Address'       => {0,0,0,0},

--- a/test/static_SUITE.erl
+++ b/test/static_SUITE.erl
@@ -12,6 +12,7 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("diameter/include/diameter_gen_base_rfc6733.hrl").
+-include_lib("gtplib/include/gtp_packet.hrl").
 -include("../include/diameter_3gpp_ts29_212.hrl").
 -include("../include/diameter_3gpp_ts32_299.hrl").
 -include("../include/ergw_aaa_session.hrl").
@@ -166,7 +167,13 @@ init_session(Session, _Config) ->
 	  '3GPP-SGSN-Address'       => {192,168,1,1},
 	  '3GPP-SGSN-MCC-MNC'       => <<"26201">>,
 	  '3GPP-Selection-Mode'     => 0,
-	  '3GPP-User-Location-Info' => <<24,98,242,16,64,163,98,242,16,1,156,232,0>>,
+	  'User-Location-Info' =>
+	      #{'ext-macro-eNB' =>
+		    #ext_macro_enb{plmn_id = {<<"001">>, <<"001">>},
+				   id = rand:uniform(16#1fffff)},
+		'TAI' =>
+		    #tai{plmn_id = {<<"001">>, <<"001">>},
+			 tac = rand:uniform(16#ffff)}},
 	  'Called-Station-Id'       => <<"some.station.gprs">>,
 	  'Calling-Station-Id'      => <<"543148000012345">>,
 	  'Framed-IP-Address'       => {10,106,14,227},


### PR DESCRIPTION
Translate structured User-Location-Info data into encoded 3GPP-User-Location-Info RADIUS and DIAMETER AVP.

Backward compatibility for binary 3GPP-User-Location-Info  is maintained.