### PR TITLE
fix handling of structured data in MCC-MNC 3GPP values

### DIFF
--- a/src/ergw_aaa_3gpp_dict.erl
+++ b/src/ergw_aaa_3gpp_dict.erl
@@ -163,6 +163,12 @@ encode('User-Location-Info', #{'CGI' := CGI})
 encode('User-Location-Info', _Value) ->
     <<>>;
 
+encode(Key, {MCC, MNC})
+  when Key =:= '3GPP-IMSI-MCC-MNC';
+       Key =:= '3GPP-GGSN-MCC-MNC';
+       Key =:= '3GPP-SGSN-MCC-MNC' ->
+    <<MCC/binary, MNC/binary>>;
+
 encode(_Key, Value) ->
     Value.
 


### PR DESCRIPTION
The conversion to handling structured data included a change to
use tuples for plmnIds as well. The MCC-MNC values are essentially
plmnIds and should therefore support tuples as well.