### PR TITLE
Add initial support for UserID in NASREQ

### DIFF
--- a/dia/diameter_3gpp_ts29_061_sgi.dia
+++ b/dia/diameter_3gpp_ts29_061_sgi.dia
@@ -175,6 +175,11 @@
             * [ Proxy-Info ]
               [ 3GPP-IPv6-DNS-Servers ]
               [ TP-NAT-Pool-Id ]
+              ;; Extensions for User-ID aware TDF
+              [ Calling-Station-Id ]
+              [ 3GPP-IMSI ]
+              [ 3GPP-IMEISV ]
+              ;;
             * [ AVP ]
 
       RAR ::= < Diameter Header: 258, REQ, PXY >

--- a/src/ergw_aaa_nasreq.erl
+++ b/src/ergw_aaa_nasreq.erl
@@ -105,6 +105,7 @@ initialize_service(_ServiceId, #{function := Function, accounting := AcctModel})
 			   {dictionary, ?DIAMETER_DICT_NASREQ},
 			   {module, ?MODULE}]
 			  | Appl]},
+    ?LOG(debug, "Registering NASREQ service: ~p", [{Function, SvcOpts}]),
     ergw_aaa_diameter_srv:register_service(Function, SvcOpts),
     {ok, []}.
 
@@ -276,7 +277,7 @@ prepare_retransmit(_Pkt, _SvcName, _Peer, _CallOpts) ->
 handle_answer(#diameter_packet{msg = Msg, errors = Errors},
 	      _Request, SvcName, Peer, _CallOpts)
   when length(Errors) /= 0 ->
-    ?LOG(error, "~p: decode of answer from ~p failed, errors ~p", [SvcName, Peer, Errors]),
+    ?LOG(error, "~p: decode of answer ~p from ~p failed, errors ~p", [SvcName, Msg, Peer, Errors]),
     ok = ergw_aaa_diameter_srv:finish_request(SvcName, Peer),
     case Msg of
 	[_ | #{'Result-Code' := RC}] -> {error, RC};	%% try to handle gracefully
@@ -398,6 +399,12 @@ to_session(_, 'Framed-Pool', [Id], {Session, Events}) ->
     {Session#{'Framed-Pool' => Id}, Events};
 to_session(_, 'Framed-IPv6-Pool', [Id], {Session, Events}) ->
     {Session#{'Framed-IPv6-Pool' => Id}, Events};
+to_session(_, '3GPP-IMSI', [Id], {Session, Events}) ->
+    {Session#{'3GPP-IMSI' => Id}, Events};
+to_session(_, '3GPP-IMEISV', [Id], {Session, Events}) ->
+    {Session#{'3GPP-IMEISV' => Id}, Events};
+to_session(_, 'Calling-Station-Id', [Id], {Session, Events}) ->
+    {Session#{'Calling-Station-Id' => Id}, Events};
 to_session(_, _, _, SessEv) ->
     SessEv.
 

--- a/test/diameter_test_server.erl
+++ b/test/diameter_test_server.erl
@@ -255,7 +255,8 @@ handle_request(#diameter_packet{msg = ['ACR' | Msg]}, _SvcName, {_, Caps}, _Extr
 	     'Accounting-Record-Number' => Number},
     case check_3gpp(Msg) of
 	Result when Result =:= ok;
-		    Result =:= {ok, no_imsi} ->
+		    Result =:= {ok, no_imsi};
+			  Result =:= {ok, cgnat} ->
 	    {reply, ['ACA' | ACA]};
 	_ ->
 	    {answer_message, 5005}
@@ -402,6 +403,10 @@ check_3gpp(#{'3GPP-IMSI'              := [<<"250071234567890">>],
 	     '3GPP-Selection-Mode'    := [<<"0">>]
 	    }) ->
     ok;
+check_3gpp(#{'3GPP-IMSI'              := [<<"250071234567890">>],
+	     '3GPP-IMEISV'            := [<<82,21,50,96,32,80,30,0>>]
+	    }) ->
+    error_m:return(cgnat);
 check_3gpp(#{'3GPP-IMSI' := [<<"noCheck">>]}) ->
     ok;
 check_3gpp(Msg) ->


### PR DESCRIPTION
The NASREQ `diameter_3gpp_ts29_061_sgi.dia` dictionary has been updated to carry user ID information in the AAA response (IMSI, IMEI and MSISDN) if available. This information will be copied over to the session if present.