### PR TITLE
[Gy/Ro]: change state atom in terminate action to stopped

### DIFF
--- a/src/ergw_aaa_ro.erl
+++ b/src/ergw_aaa_ro.erl
@@ -156,7 +156,7 @@ invoke(_Service, {_, Procedure}, Session, Events, _Opts, State)
        Procedure =:= 'CCR-Terminate' ->
     {ok, Session, Events, State};
 invoke(_Service, terminate, Session, Events, _Opts, State) ->
-    {ok, Session, Events, State};
+    {ok, Session, Events, State#state{state = stopped}};
 
 invoke(Service, Procedure, Session, Events, _Opts, State) ->
     {{error, {Service, Procedure}}, Session, Events, State}.


### PR DESCRIPTION
In some circumstance (mostly ocs_hold), terminate is incoked, but does not need to send out
anything. In that cases the session state was not updated to `stopped`, resulting in the
metrics gathering to keep the session in a wrong state.