### PR TITLE
switch session state to stopped after receiving a DIAMETER error

### DIFF
--- a/src/ergw_aaa_nasreq.erl
+++ b/src/ergw_aaa_nasreq.erl
@@ -342,9 +342,9 @@ handle_aaa(['AAA' | #{'Result-Code' := RC} = Avps], Session0, Events0, _Opts, St
     {ok, Session, Events, State};
 handle_aaa([Answer | #{'Result-Code' := Code}], Session, Events, _Opts, State)
   when Answer =:= 'AAA'; Answer =:= 'answer-message' ->
-    {{fail, Code}, Session, Events, State};
+    {{fail, Code}, Session, Events, State#state{state = stopped}};
 handle_aaa({error, _} = Result, Session, Events, _Opts, State) ->
-    {Result, Session, Events, State}.
+    {Result, Session, Events, State#state{state = stopped}}.
 
 handle_aca(['ACA' | #{'Result-Code' := RC} = Avps], Session0, Events0, _Opts, State)
   when RC < 3000 ->

--- a/src/ergw_aaa_ro.erl
+++ b/src/ergw_aaa_ro.erl
@@ -341,7 +341,7 @@ handle_cca(['CCA' | #{'Result-Code' := Code} = Avps],
     {ok, Session, Events, State};
 handle_cca([Answer | #{'Result-Code' := Code}], Session, Events, _Opts, State)
   when Answer =:= 'CCA'; Answer =:= 'answer-message' ->
-    {{fail, Code}, Session, [{stop, {?API, peer_reject}} | Events], State};
+    {{fail, Code}, Session, [{stop, {?API, peer_reject}} | Events], State#state{state = stopped}};
 handle_cca({error, no_connection}, Session, Events,
 	   #{answer_if_down := Answer, answers := Answers} = Opts, State0) ->
     {Avps, State} =

--- a/src/ergw_aaa_session.erl
+++ b/src/ergw_aaa_session.erl
@@ -219,6 +219,11 @@ handle_event({call, From}, {set, Values}, _State, Data) ->
 handle_event({call, From}, {unset, Options}, _State, Data = #data{session = Session}) ->
     {keep_state, Data#data{session = maps:without(Options, Session)}, [{reply, From, ok}]};
 
+handle_event(info, {'EXIT', Owner, normal = Reason},
+	     _State, #data{owner = Owner} = Data) ->
+    ?LOG(debug, "Received EXIT signal for ~p with reason ~p", [Owner, Reason]),
+    terminate_action(Data),
+    {stop, normal};
 handle_event(info, {'EXIT', Owner, Reason},
 	     _State, #data{owner = Owner} = Data) ->
     ?LOG(error, "Received EXIT signal for ~p with reason ~p", [Owner, Reason]),

--- a/test/diameter_Rf_SUITE.erl
+++ b/test/diameter_Rf_SUITE.erl
@@ -555,6 +555,7 @@ handle_failure(Config) ->
     ?match({{fail, 3001}, _, _},
 	   ergw_aaa_session:invoke(SId, #{}, {rf, 'Initial'}, SOpts)),
 
+    %% a session that has been rejected can not be in a `started` state
     ?equal([{ergw_aaa_rf, started, 1}], get_session_stats()),
 
     Statistics = diff_stats(Stats0, get_stats(?SERVICE)),

--- a/test/diameter_nasreq_SUITE.erl
+++ b/test/diameter_nasreq_SUITE.erl
@@ -303,6 +303,7 @@ handle_failure(Config) ->
 
     ?match({{fail, 3007}, _, _}, ergw_aaa_session:start(Session, #{}, [])),
 
+    %% a accounting error is not treated as session stop
     ?equal([{ergw_aaa_nasreq, started, 1}], get_session_stats()),
 
     ?match({{fail, 3007}, _, _}, ergw_aaa_session:stop(Session, #{}, [])),
@@ -321,6 +322,7 @@ handle_answer_error(Config) ->
 
     ?match({{error, 3007}, _, _}, ergw_aaa_session:start(Session, #{}, [])),
 
+    %% a accounting error is not treated as session stop
     ?equal([{ergw_aaa_nasreq, started, 1}], get_session_stats()),
 
     ?match({{error, 3007}, _, _}, ergw_aaa_session:stop(Session, #{}, [])),


### PR DESCRIPTION
This ensures that session do not send termination requests after the session
was stopped by a previous error.