### PR TITLE
Add Origin-Host configuration at app level

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 ergw-aaa
 ========
 
+Version 4.4.0 - 1 June 2023
+--------------------------------
+
+**Features** :bug:
+* [#203](https://github.com/travelping/ergw_aaa/pull/203) Allow a configurable `Origin-Host` value per app.
+
 Version 4.3.5 - 30 January 2022
 --------------------------------
 

--- a/README.md
+++ b/README.md
@@ -182,29 +182,32 @@ Example of possible config.
    {services,
     [{'Default',     [{handler, 'ergw_aaa_static'}]},
      {'RADIUS-Auth', [{handler, 'ergw_aaa_radius'},
-	                  {server, {{127,1,0,1}, 1812, <<"secret">>}}]},
+                      {server, {{127,1,0,1}, 1812, <<"secret">>}}]},
      {'RADIUS-Acct', [{handler, 'ergw_aaa_radius'},
-	                  {server, {{127,2,0,1}, 1813, <<"secret">>}}]},
+                      {server, {{127,2,0,1}, 1813, <<"secret">>}}]},
      {'Rf',          [{handler, 'ergw_aaa_rf'}]},
      {'Gx',          [{handler, 'ergw_aaa_gx'}]}
      {'Gy',          [{handler, 'ergw_aaa_ro'}]}
     ]},
 
    {apps,
-    [{default,
-      [{session, ['Default']},
-       {procedures, [{authenticate, ['RADIUS-Auth']},
-                     {authorize,    ['RADIUS-Auth']},
-                     {start,     ['RADIUS-Acct', 'Rf']},
-                     {interim,   ['RADIUS-Acct', 'Rf']},
-                     {stop,      ['RADIUS-Acct', 'Rf']},
-                     {{gx, 'CCR-Initial'},   ['Gx']},
-                     {{gx, 'CCR-Update'},    ['Gx']},
-                     {{gx, 'CCR-Terminate'}, ['Gx']},
-                     {{gy, 'CCR-Initial'},   ['Gy']},
-                     {{gy, 'CCR-Update'},    ['Gy']},
-                     {{gy, 'CCR-Terminate'}, ['Gy']}]}
-      ]}
+    [ {'Origin-Host', <<"local.host">>},
+      {procedures,
+        [{default,
+          [{session, ['Default']},
+           {procedures, [{authenticate, ['RADIUS-Auth']},
+                         {authorize,    ['RADIUS-Auth']},
+                         {start,     ['RADIUS-Acct', 'Rf']},
+                         {interim,   ['RADIUS-Acct', 'Rf']},
+                         {stop,      ['RADIUS-Acct', 'Rf']},
+                         {{gx, 'CCR-Initial'},   ['Gx']},
+                         {{gx, 'CCR-Update'},    ['Gx']},
+                         {{gx, 'CCR-Terminate'}, ['Gx']},
+                         {{gy, 'CCR-Initial'},   ['Gy']},
+                         {{gy, 'CCR-Update'},    ['Gy']},
+                         {{gy, 'CCR-Terminate'}, ['Gy']}]}
+          ]}
+        ]}
     ]}
   ]},
 ```

--- a/src/ergw_aaa_config.erl
+++ b/src/ergw_aaa_config.erl
@@ -120,14 +120,21 @@ validate_service(Service, Opts)
 validate_service(Service, Opts) ->
     erlang:error(badarg, [Service, Opts]).
 
-validate_app(App, Procedures)
-  when is_map(Procedures) ->
+validate_app(App, AppOptions)
+  when is_map(AppOptions) ->
+    maps:map(validate_app_option(App, _, _ ), AppOptions);
+validate_app(App, AppOptions)
+  when is_list(AppOptions) ->
+    validate_app(App, to_map(AppOptions));
+validate_app(App, AppOptions) ->
+    erlang:error(badarg, [App, AppOptions]).
+
+validate_app_option(_, 'Origin-Host', Host) when is_binary(Host) -> 
+    Host;
+validate_app_option(App, procedures, Procedures) -> 
     validate_options(validate_app_procs_option(App, _, _), Procedures, []);
-validate_app(App, Procedures)
-  when is_list(Procedures) ->
-    validate_app(App, to_map(Procedures));
-validate_app(App, Procedures) ->
-    erlang:error(badarg, [App, Procedures]).
+validate_app_option(App, Opt, Value) ->
+    erlang:error(badarg, [App, Opt, Value]).
 
 validate_app_procs_option(App, Procedure, Services)
   when is_list(Services) ->

--- a/src/ergw_aaa_session.erl
+++ b/src/ergw_aaa_session.erl
@@ -433,8 +433,8 @@ services(Procedure, App) ->
     maps:get(Procedure, App, []).
 
 action(Procedure, Opts, #data{application = AppId} = Data) ->
-    App = ergw_aaa:get_application(AppId),
-    Pipeline = services(Procedure, App),
+    #{procedures := Procedures} = ergw_aaa:get_application(AppId),
+    Pipeline = services(Procedure, Procedures),
     pipeline(Procedure, Data, [], Opts, Pipeline).
 
 pipeline(_, Data, Events, _Opts, []) ->

--- a/test/diameter_Gx_SUITE.erl
+++ b/test/diameter_Gx_SUITE.erl
@@ -67,16 +67,20 @@
 	       },
 	  apps =>
 	      #{default =>
-		    #{init => [#{service => <<"Default">>}],
-		      authenticate => [],
-		      authorize => [],
-		      start => [#{service => <<"NASREQ">>}],
-		      interim => [#{service => <<"NASREQ">>}],
-		      stop => [#{service => <<"NASREQ">>}],
-		      {gx, 'CCR-Initial'}   => [#{service => <<"Gx">>}],
-		      {gx, 'CCR-Update'}    => [#{service => <<"Gx">>}],
-		      {gx, 'CCR-Terminate'} => [#{service => <<"Gx">>}]}}
-	 }).
+		    #{'Origin-Host' => <<"dummy.host">>,
+		      procedures =>
+			  #{init => [#{service => <<"Default">>}],
+			    authenticate => [],
+			    authorize => [],
+			    start => [#{service => <<"NASREQ">>}],
+			    interim => [#{service => <<"NASREQ">>}],
+			    stop => [#{service => <<"NASREQ">>}],
+			    {gx, 'CCR-Initial'}   => [#{service => <<"Gx">>}],
+			    {gx, 'CCR-Update'}    => [#{service => <<"Gx">>}],
+			    {gx, 'CCR-Terminate'} => [#{service => <<"Gx">>}]}
+		    }
+	      }
+	}).
 
 %%%===================================================================
 %%% Common Test callbacks

--- a/test/diameter_Gy_SUITE.erl
+++ b/test/diameter_Gy_SUITE.erl
@@ -94,27 +94,29 @@
 	       },
 	  apps =>
 	      #{default =>
-		    #{init => [#{service => <<"Default">>}],
-		      authenticate => [],
-		      authorize => [],
-		      start => [],
-		      interim => [],
-		      stop => [],
-		      {gy, 'CCR-Initial'} =>
-			  [#{service => <<"Ro">>,
-			     tx_timeout => 1000,
-			     max_retries => 2,
-			     answer_if_down => <<"OCS-Hold">>,
-			     answer_if_timeout => <<"OCS-Hold">>}],
-		      {gy, 'CCR-Update'} =>
-			  [#{service => <<"Ro">>,
-			     tx_timeout => 1000,
-			     answer_if_down => <<"OCS-Hold">>,
-			     answer_if_timeout => <<"OCS-Hold">>}],
-		      {gy, 'CCR-Terminate'} =>
-			  [#{service => <<"Ro">>}]}
+		  #{'Origin-Host' => <<"dummy.host">>,
+		    procedures =>
+			#{init => [#{service => <<"Default">>}],
+			  authenticate => [],
+			  authorize => [],
+			  start => [],
+			  interim => [],
+			  stop => [],
+			  {gy, 'CCR-Initial'} =>
+			      [#{service => <<"Ro">>,
+				 tx_timeout => 1000,
+				 max_retries => 2,
+				 answer_if_down => <<"OCS-Hold">>,
+				 answer_if_timeout => <<"OCS-Hold">>}],
+			  {gy, 'CCR-Update'} =>
+			      [#{service => <<"Ro">>,
+				 tx_timeout => 1000,
+				 answer_if_down => <<"OCS-Hold">>,
+				 answer_if_timeout => <<"OCS-Hold">>}],
+			  {gy, 'CCR-Terminate'} =>
+			      [#{service => <<"Ro">>}]}
 	       }
-	 }).
+	 }}).
 
 %%%===================================================================
 %%% Common Test callbacks

--- a/test/diameter_Rf_SUITE.erl
+++ b/test/diameter_Rf_SUITE.erl
@@ -58,18 +58,21 @@
 		<<"Rf">> =>
 		    #{handler => 'ergw_aaa_rf'}},
 	  apps =>
-	    #{default =>
-		    #{init => [#{service => <<"Default">>}],
-		      authenticate => [],
-		      authorize => [],
-		      start => [],
-		      interim => [],
-		      stop => [],
-		      {rf, 'Initial'}   => [#{service => <<"Rf">>}],
-		      {rf, 'Update'}    => [#{service => <<"Rf">>}],
-		      {rf, 'Terminate'} => [#{service => <<"Rf">>}]
-		     }
-	       }
+	      #{default =>
+		    #{'Origin-Host' => <<"dummy.host">>,
+		      procedures =>
+			  #{init => [#{service => <<"Default">>}],
+			    authenticate => [],
+			    authorize => [],
+			    start => [],
+			    interim => [],
+			    stop => [],
+			    {rf, 'Initial'}   => [#{service => <<"Rf">>}],
+			    {rf, 'Update'}    => [#{service => <<"Rf">>}],
+			    {rf, 'Terminate'} => [#{service => <<"Rf">>}]
+			  }
+	            }
+	      }
        }).
 
 %%%===================================================================

--- a/test/diameter_avp_filter_SUITE.erl
+++ b/test/diameter_avp_filter_SUITE.erl
@@ -82,16 +82,19 @@
 		    #{handler => 'ergw_aaa_ro'}},
 	  apps =>
 	      #{default =>
-		    #{init => [#{service => <<"Default">>}],
-		      authenticate => [],
-		      authorize => [],
-		      start => [],
-		      interim => [],
-		      stop => [],
-		      {gy, 'CCR-Initial'} => [#{service => <<"Ro">>}],
-		      {gy, 'CCR-Update'} => [#{service => <<"Ro">>}],
-		      {gy, 'CCR-Terminate'} => [#{service => <<"Ro">>}]}
-	       }
+		    #{'Origin-Host' => <<"dummy.host">>,
+		      procedures =>
+			  #{init => [#{service => <<"Default">>}],
+			    authenticate => [],
+			    authorize => [],
+			    start => [],
+			    interim => [],
+			    stop => [],
+			    {gy, 'CCR-Initial'} => [#{service => <<"Ro">>}],
+			    {gy, 'CCR-Update'} => [#{service => <<"Ro">>}],
+			    {gy, 'CCR-Terminate'} => [#{service => <<"Ro">>}]}
+		    }
+	      }
 	 }).
 
 %%%===================================================================

--- a/test/diameter_nasreq_SUITE.erl
+++ b/test/diameter_nasreq_SUITE.erl
@@ -57,14 +57,17 @@
 		    #{handler => 'ergw_aaa_nasreq'}},
 	  apps =>
 	      #{default =>
-		    #{init => [#{service => <<"Default">>}],
-		      authenticate => [#{service => <<"NASREQ">>}],
-		      authorize => [#{service => <<"NASREQ">>}],
-		      start => [#{service => <<"NASREQ">>}],
-		      interim => [#{service => <<"NASREQ">>}],
-		      stop => [#{service => <<"NASREQ">>}]
-		     }
-	       }
+		    #{'Origin-Host' => <<"dummy.host">>,
+		      procedures =>
+			  #{init => [#{service => <<"Default">>}],
+			    authenticate => [#{service => <<"NASREQ">>}],
+			    authorize => [#{service => <<"NASREQ">>}],
+			    start => [#{service => <<"NASREQ">>}],
+			    interim => [#{service => <<"NASREQ">>}],
+			    stop => [#{service => <<"NASREQ">>}]
+			  }
+		    }
+	      }
 	 }).
 
 %%%===================================================================

--- a/test/radius_SUITE.erl
+++ b/test/radius_SUITE.erl
@@ -57,13 +57,16 @@
 			    secret => <<"secret">>}}},
 	  apps =>
 	      #{default =>
-		    #{init         => [#{service => <<"Default">>}],
-		      authenticate => [#{service => <<"RADIUS-Auth">>}],
-		      authorize    => [#{service => <<"RADIUS-Auth">>}],
-		      start        => [#{service => <<"RADIUS-Acct">>}],
-		      interim      => [#{service => <<"RADIUS-Acct">>}],
-		      stop         => [#{service => <<"RADIUS-Acct">>}]}
-	       }
+		    #{'Origin-Host' => <<"dummy.host">>,
+		      procedures =>
+			  #{init         => [#{service => <<"Default">>}],
+			    authenticate => [#{service => <<"RADIUS-Auth">>}],
+			    authorize    => [#{service => <<"RADIUS-Auth">>}],
+			    start        => [#{service => <<"RADIUS-Acct">>}],
+			    interim      => [#{service => <<"RADIUS-Acct">>}],
+			    stop         => [#{service => <<"RADIUS-Acct">>}]}
+		    }
+	     }
 	 }).
 
 %%%===================================================================
@@ -408,7 +411,7 @@ set_service_pars(NewOpts) ->
     Apps =
 	lists:foldl(
 	  fun(P, A) ->
-		  maps_update_with([default, P], Upd, A)
+		  maps_update_with([default, procedures, P], Upd, A)
 	  end, Apps0, [authenticate, start, interim, stop]),
     application:set_env(ergw_aaa, apps, Apps),
     Apps0.

--- a/test/static_SUITE.erl
+++ b/test/static_SUITE.erl
@@ -97,19 +97,22 @@
 
 	  apps =>
 	      #{default =>
-		    #{init => [#{service => <<"Default">>}],
-		      authenticate => [],
-		      authorize => [],
-		      start => [],
-		      interim => [],
-		      stop => [],
-		      {gx, 'CCR-Initial'}   => [#{service => <<"Default">>, answer => <<"Initial-Gx">>}],
-		      {gx, 'CCR-Update'}    => [#{service => <<"Default">>, answer => <<"Update-Gx">>}],
-		      {gx, 'CCR-Terminate'} => [#{service => <<"Default">>, answer => <<"Final-Gx">>}],
-		      {gy, 'CCR-Initial'}   => [#{service => <<"Default">>, answer => <<"Initial-Gy">>}],
-		      {gy, 'CCR-Update'}    => [#{service => <<"Default">>, answer => <<"Update-Gy">>}],
-		      {gy, 'CCR-Terminate'} => []
-		      }
+		    #{'Origin-Host' => <<"dummy.host">>,
+		      procedures =>
+			    #{init => [#{service => <<"Default">>}],
+			      authenticate => [],
+			      authorize => [],
+			      start => [],
+			      interim => [],
+			      stop => [],
+			      {gx, 'CCR-Initial'}   => [#{service => <<"Default">>, answer => <<"Initial-Gx">>}],
+			      {gx, 'CCR-Update'}    => [#{service => <<"Default">>, answer => <<"Update-Gx">>}],
+			      {gx, 'CCR-Terminate'} => [#{service => <<"Default">>, answer => <<"Final-Gx">>}],
+			      {gy, 'CCR-Initial'}   => [#{service => <<"Default">>, answer => <<"Initial-Gy">>}],
+			      {gy, 'CCR-Update'}    => [#{service => <<"Default">>, answer => <<"Update-Gy">>}],
+			      {gy, 'CCR-Terminate'} => []
+			      }
+		    }
 	       }
 	 }).
 


### PR DESCRIPTION
The current `app` configuration does not allow the `Origin-Host` to be set, even though there is actually support for it in the rest of the code.
The `app` configuration spec will be updated. Instead of holding the procedures themselves, two attributes will be supported:

* `procedures` holding the procedure configuration; and
* `Origin-Host`, which will be used to build the `Session-Id` AVP. 

If this option is not present, the localhost resolved as `net_adm:localhost()` will be used instead.