### PR TITLE
Fix default apps value

### DIFF
--- a/src/ergw_aaa.erl
+++ b/src/ergw_aaa.erl
@@ -112,7 +112,7 @@ get_service(Name) ->
 
 get_application(Name) ->
     Apps = application:get_env(ergw_aaa, ?APP_KEY, #{}),
-    maps:get(Name, Apps, #{}).
+    maps:get(Name, Apps, #{procedures => #{}}).
 
 %%===================================================================
 %% Internal

--- a/src/ergw_aaa_config.erl
+++ b/src/ergw_aaa_config.erl
@@ -122,7 +122,7 @@ validate_service(Service, Opts) ->
 
 validate_app(App, AppOptions)
   when is_map(AppOptions) ->
-    maps:map(validate_app_option(App, _, _ ), AppOptions);
+    maps:map(validate_app_option(App, _, _ ), maps:merge(#{procedures => #{}}, AppOptions));
 validate_app(App, AppOptions)
   when is_list(AppOptions) ->
     validate_app(App, to_map(AppOptions));


### PR DESCRIPTION
The format for the apps configuration value has changed, so the default values are no longer valid.