### PR TITLE
[CENNSO-1088] Fix translation of release cause codes

### DIFF
--- a/src/ergw_aaa_diameter_srv.erl
+++ b/src/ergw_aaa_diameter_srv.erl
@@ -179,8 +179,8 @@ call(App, Request, #{function := Function} = Config, CallOpts) ->
 	    case Error of
 		encode ->
 		    ?LOG(critical, "failed to encode DIAMETER requests: ~0p", [Request]);
-		_ ->
-		    ok
+		Other ->
+		    ?LOG(notice, "non-critical diameter API: ~p", [Other])
 	    end,
 	    SI = diameter:service_info(Function, applications),
 	    handle_plain_error(Result, Request, Function, App, CallOpts, SI);

--- a/src/ergw_aaa_gx.erl
+++ b/src/ergw_aaa_gx.erl
@@ -299,6 +299,9 @@ handle_cca({error, no_connection}, Session, Events,
 	   #{answer_if_timeout := Answer, answers := Answers} = Opts, State) ->
     Avps = apply_answer_config(Answer, Answers),
     handle_cca(['CCA' | Avps], Session, Events, Opts, State);
+handle_cca({error, Code} = Result, Session, Events, _Opts, State)
+  when is_integer(Code) ->
+    {Result, Session, [{stop, {?API, peer_reject}} | Events], State#state{state = stopped}};
 handle_cca({error, Reason} = Result, Session, Events, _Opts, State) ->
     ?LOG(error, "CCA Result: ~p", [Result]),
     {Result, Session, [{stop, {?API, Reason}} | Events], State#state{state = stopped}}.

--- a/src/ergw_aaa_ro.erl
+++ b/src/ergw_aaa_ro.erl
@@ -355,6 +355,9 @@ handle_cca({error, rate_limit}, Session, Events,
 	   #{answer_if_rate_limit := Answer, answers := Answers} = Opts, State0) ->
     {Avps, State} = apply_answer_config(Answer, Answers, State0),
     handle_cca(['CCA' | Avps], Session, Events, Opts, State);
+handle_cca({error, Code} = Result, Session, Events, _Opts, State)
+  when is_integer(Code) ->
+    {Result, Session, [{stop, {?API, peer_reject}} | Events], State#state{state = stopped}};
 handle_cca({error, Reason} = Result, Session, Events, _Opts, State) ->
     ?LOG(error, "CCA Result: ~p", [Result]),
     {Result, Session, [{stop, {?API, Reason}} | Events], State#state{state = stopped}}.


### PR DESCRIPTION
A release cause is sometimes reported as a `{error, Cause}` tuple where `Cause` is the integer Diameter error. To provide a consistent interface, this cause is translated to an atom.