### PR TITLE
[CENNSO-1606] Rf: copy some PS-Information into the following requests

### DIFF
--- a/dia/diameter_3gpp_ts32_299.dia
+++ b/dia/diameter_3gpp_ts32_299.dia
@@ -354,7 +354,7 @@
    Served-Party-IP-Address                                       848          Address     MV
    Service-Data-Container                                       2040          Grouped     MV
    Service-Id                                                    855       UTF8String     MV
-   Service-Information                                           873          Grouped     MV
+;; Service-Information                                           873          Grouped     MV
    Service-Mode                                                 2032       Unsigned32     MV
    Service-Specific-Data                                         863       UTF8String     MV
    Service-Specific-Info                                        1249          Grouped     MV
@@ -1171,25 +1171,26 @@
 ;;         [ Traffic-Steering-Policy-Identifier-DL ]
 ;;         [ Traffic-Steering-Policy-Identifier-UL ]
 
-   Service-Information ::= < AVP Header: 873>
-
-         * [ Subscription-Id ]
-           [ AoC-Information ]
-           [ PS-Information ]
-           [ IMS-Information ]
-           [ MMS-Information ]
-           [ LCS-Information ]
-           [ PoC-Information ]
-           [ MBMS-Information ]
-           [ SMS-Information ]
-           [ VCS-Information ]
-           [ MMTel-Information ]
-           [ ProSe-Information ]
+;; Service-Information ::= < AVP Header: 873>
+;;
+;;       * [ Subscription-Id ]
+;;         [ AoC-Information ]
+;;         [ PS-Information ]
+;;         [ TP-Previous-PS-Information ]
+;;         [ IMS-Information ]
+;;         [ MMS-Information ]
+;;         [ LCS-Information ]
+;;         [ PoC-Information ]
+;;         [ MBMS-Information ]
+;;         [ SMS-Information ]
+;;         [ VCS-Information ]
+;;         [ MMTel-Information ]
+;;         [ ProSe-Information ]
 ;;         [ Service-Generic-Information ]
 ;;         [ IM-Information ]
 ;;         [ DCD-Information ]
 ;;         [ M2M-Information ]
-           [ CPDT-Information ]
+;;         [ CPDT-Information ]
 
    Service-Specific-Info  ::= < AVP Header: 1249 >
 

--- a/dia/diameter_3gpp_ts32_299_rf.dia
+++ b/dia/diameter_3gpp_ts32_299_rf.dia
@@ -34,6 +34,8 @@
 @inherits diameter_3gpp_ts29_214
 @inherits diameter_3gpp_ts29_329
 @inherits diameter_3gpp_ts32_299
+@inherits diameter_travelping
+@inherits diameter_3gpp_ts32_299_si
 
 ;; ===========================================================================
 

--- a/dia/diameter_3gpp_ts32_299_ro.dia
+++ b/dia/diameter_3gpp_ts32_299_ro.dia
@@ -33,6 +33,8 @@
 @inherits diameter_3gpp_ts29_214
 @inherits diameter_3gpp_ts29_329
 @inherits diameter_3gpp_ts32_299
+@inherits diameter_travelping
+@inherits diameter_3gpp_ts32_299_si
 
 ;; ===========================================================================
 

--- a/dia/diameter_3gpp_ts32_299_si.dia
+++ b/dia/diameter_3gpp_ts32_299_si.dia
@@ -1,0 +1,69 @@
+;;
+;; %CopyrightBegin%
+;;
+;; Copyright Travelping GmbH 2024. All Rights Reserved.
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+;; %CopyrightEnd%
+;;
+
+@id     0
+@name   diameter_3gpp_ts32_299_si
+@prefix diameter_3gpp_charging
+@vendor 10415 3GPP
+
+@inherits diameter_gen_base_rfc6733
+@inherits diameter_gen_acct_rfc6733
+@inherits diameter_rfc7155_nasreq
+@inherits diameter_rfc4006_cc
+@inherits diameter_etsi_es283_034
+@inherits diameter_3gpp_base
+@inherits diameter_3gpp_ts29_061_gmb
+@inherits diameter_3gpp_ts29_212
+@inherits diameter_3gpp_ts29_214
+@inherits diameter_3gpp_ts29_329
+
+@inherits diameter_3gpp_ts32_299
+@inherits diameter_travelping
+
+;; ===========================================================================
+
+@avp_types
+
+   Service-Information                                           873          Grouped     MV
+
+;; ===========================================================================
+
+@grouped
+
+   Service-Information ::= < AVP Header: 873>
+
+         * [ Subscription-Id ]
+           [ AoC-Information ]
+           [ PS-Information ]
+           [ TP-Previous-PS-Information ]
+           [ IMS-Information ]
+           [ MMS-Information ]
+           [ LCS-Information ]
+           [ PoC-Information ]
+           [ MBMS-Information ]
+           [ SMS-Information ]
+           [ VCS-Information ]
+           [ MMTel-Information ]
+           [ ProSe-Information ]
+;;         [ Service-Generic-Information ]
+;;         [ IM-Information ]
+;;         [ DCD-Information ]
+;;         [ M2M-Information ]
+           [ CPDT-Information ]

--- a/dia/diameter_travelping.dia
+++ b/dia/diameter_travelping.dia
@@ -6,11 +6,18 @@
 ;; 2 of the License, or (at your option) any later version.
 
 ;; It contains custom Travelping AVPs related to NAT-binding
+;; When adding AVPs make sure to use values not already used by the
+;; Travelping RADIUS dictionary:
+;;   https://github.com/travelping/eradius/blob/2.3.1/priv/dictionaries/dictionary.travelping
 
 @id     1
 @name   diameter_travelping
 @prefix diameter_travelping
 @vendor 18681 Travelping
+
+@inherits diameter_3gpp_base
+@inherits diameter_3gpp_ts29_212
+@inherits diameter_3gpp_ts32_299
 
 @avp_types
 
@@ -18,3 +25,18 @@
    TP-NAT-Pool-Id                27     UTF8String     V
    TP-NAT-Port-Start             28     Unsigned32     V
    TP-NAT-Port-End               29     Unsigned32     V
+   TP-Previous-PS-Information    64        Grouped     V
+
+;; ===========================================================================
+
+@grouped
+
+   TP-Previous-PS-Information ::= < AVP Header: 64>
+
+           [ QoS-Information ]
+         * [ SGSN-Address ]
+           [ 3GPP-SGSN-MCC-MNC ]
+           [ 3GPP-MS-TimeZone ]
+           [ 3GPP-User-Location-Info ]
+           [ 3GPP-RAT-Type ]
+         * [ AVP ]


### PR DESCRIPTION
copy some PS-Information into the following requests and encode them in the TP-Previous-PS-Information vendor AVP.
This helps out legacy (v1/v2 ) CDF to include the correct information in the CDR.

WARNING: The TS 32.299 dictionary does not make the Service-Information group extendable.
         Adding the vendor AVP TP-Previous-PS-Information to that group is therefore not backward
         compatible. Use Diameter AVP filters to strip that new AVP when integration with
         an CDF without support for that AVP is needed.