### PR TITLE
Mute normal end process monitor events

### DIFF
--- a/src/ergw_aaa_session.erl
+++ b/src/ergw_aaa_session.erl
@@ -301,7 +301,10 @@ handle_event(cast, terminate, _State, Data) ->
 
 handle_event(info, {'DOWN', _Ref, process, Owner, Info},
 	     _State, #data{owner = Owner} = Data) ->
-    ?LOG(error, "Received DOWN information for ~p with info ~p", [Data#data.owner, Info]),
+    case Info of
+	normal -> ok;
+	_ -> ?LOG(error, "Received DOWN information for ~p with info ~p", [Data#data.owner, Info])
+    end,
     terminate_action(Data),
     {stop, normal};
 


### PR DESCRIPTION
When the process monitored by the `ergw_aaa` session ends, a log is only needed if the reason is different from `normal`. Otherwise these logs will obscure other more important logs.